### PR TITLE
feat: Add division filtering and Apple Music album search caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,5 +185,6 @@ competition_overview.png
 nmjanitsjar-scraper-*/
 node_modules/
 
-# Local credentials
+# Local credentials and cache files
 config/streaming_credentials.json
+config/streaming_cache.json

--- a/CACHE_FILE_MANAGEMENT.md
+++ b/CACHE_FILE_MANAGEMENT.md
@@ -1,0 +1,259 @@
+# Cache File Management
+
+## Overview
+
+The streaming search feature uses a cache file (`config/streaming_cache.json`) to store:
+- Album track listings from Spotify and Apple Music
+- Album search results from Apple Music (for years ≥ 2012)
+
+This dramatically reduces API calls and prevents rate limiting issues.
+
+## Why the Cache File is NOT in Git
+
+### Problem
+The cache file has several characteristics that make it unsuitable for version control:
+
+1. **Size**: Can grow to 8+ MB (272,504 lines in some cases)
+2. **Frequency**: Changes on every run
+3. **Machine-specific**: Contains local API response data
+4. **No collaborative value**: Each developer/machine should maintain their own cache
+5. **Noise**: Would create massive, meaningless diffs in pull requests
+
+### Solution
+The cache file is now:
+- ✅ Ignored by git (via `.gitignore`)
+- ✅ Created automatically on first run
+- ✅ Maintained locally per machine
+- ✅ Documented with an example template
+
+## File Locations
+
+```
+config/
+├── streaming_cache.json          # Local only (ignored by git)
+├── streaming_cache.json.example  # Tracked template
+└── streaming_credentials.json    # Local only (ignored by git)
+```
+
+## Setup for New Developers
+
+When cloning the repository, the cache file won't exist. It will be created automatically on first run of the streaming search script.
+
+**Optional manual creation:**
+```bash
+cp config/streaming_cache.json.example config/streaming_cache.json
+```
+
+## Cache Structure
+
+```json
+{
+  "spotify": {
+    "album_tracks": {
+      "album_id_123": {
+        "tracks": [...],
+        "fetched_at": 1690000000.0
+      }
+    }
+  },
+  "apple": {
+    "album_tracks": {
+      "collection_id_456": {
+        "tracks": [...],
+        "fetched_at": 1690000000.0
+      }
+    },
+    "album_searches": {
+      "2023|2. divisjon": {
+        "albums": [...],
+        "fetched_at": 1690000000.0
+      }
+    }
+  }
+}
+```
+
+## Cache Management
+
+### View Cache Contents
+```bash
+# View entire cache
+cat config/streaming_cache.json | jq '.'
+
+# View Apple Music album searches only
+cat config/streaming_cache.json | jq '.apple.album_searches'
+
+# View Spotify album tracks only
+cat config/streaming_cache.json | jq '.spotify.album_tracks'
+
+# Check cache file size
+ls -lh config/streaming_cache.json
+```
+
+### Clear Specific Cache Entries
+
+**Option 1: Manual editing**
+1. Open `config/streaming_cache.json` in an editor
+2. Remove specific keys (e.g., `"2023|2. divisjon"` under `apple.album_searches`)
+3. Save the file
+
+**Option 2: Using jq**
+```bash
+# Remove a specific album search cache entry
+jq 'del(.apple.album_searches["2023|2. divisjon"])' \
+  config/streaming_cache.json > config/streaming_cache.json.tmp
+mv config/streaming_cache.json.tmp config/streaming_cache.json
+```
+
+### Full Cache Reset
+```bash
+# Backup current cache (optional)
+cp config/streaming_cache.json config/streaming_cache.json.backup
+
+# Delete cache (will be recreated on next run)
+rm config/streaming_cache.json
+
+# Or reset to empty template
+cp config/streaming_cache.json.example config/streaming_cache.json
+```
+
+## Cache Benefits
+
+### Before Caching
+- Every run makes full API calls to Apple Music and Spotify
+- Rate limits hit quickly (especially Apple Music)
+- 403 Forbidden errors common
+- Slow processing times
+
+### After Caching
+- Subsequent runs use cached data
+- Minimal API calls (only for new data)
+- Dramatically reduced rate limiting
+- Fast processing (instant cache hits)
+
+## Cache Invalidation Strategy
+
+**Current approach: Manual**
+- No automatic expiration
+- Cache entries persist indefinitely
+- Manual cleanup as needed
+
+**Why manual?**
+- Competition data doesn't change frequently
+- Albums and tracks are relatively stable
+- Prevents unnecessary re-fetching
+- Developer has full control
+
+**When to clear cache:**
+- Albums/tracks updated on streaming services
+- Switching between different competition years
+- Testing cache implementation
+- Disk space concerns
+
+## Git Configuration
+
+**.gitignore entry:**
+```gitignore
+# Local credentials and cache files
+config/streaming_credentials.json
+config/streaming_cache.json
+```
+
+**What IS tracked:**
+```
+config/streaming_cache.json.example    ✅ Template file
+config/streaming_overrides.json       ✅ Manual overrides (shared)
+```
+
+**What is NOT tracked:**
+```
+config/streaming_cache.json            ❌ Machine-specific cache
+config/streaming_credentials.json      ❌ API credentials
+```
+
+## Migration from Tracked to Untracked
+
+If you had the cache file tracked before:
+
+```bash
+# Remove from git tracking (keeps local file)
+git rm --cached config/streaming_cache.json
+
+# Add to .gitignore
+echo "config/streaming_cache.json" >> .gitignore
+
+# Commit the change
+git add .gitignore
+git commit -m "chore: Move streaming_cache.json to gitignore"
+```
+
+## Best Practices
+
+1. **Never commit the cache file**
+   - It's already in `.gitignore`
+   - If accidentally staged, unstage it immediately
+
+2. **Keep credentials separate**
+   - `streaming_credentials.json` is also ignored
+   - Never commit API keys
+
+3. **Share overrides, not cache**
+   - `streaming_overrides.json` is tracked (manual corrections)
+   - Cache is generated locally
+
+4. **Backup before major changes**
+   - Cache can take time to rebuild
+   - Keep a backup during testing
+
+5. **Monitor cache size**
+   - Check occasionally: `ls -lh config/streaming_cache.json`
+   - Consider clearing old entries if >10MB
+
+## Troubleshooting
+
+### Cache file doesn't exist
+**Normal**: It's created automatically on first run. No action needed.
+
+### Cache file is huge (>20MB)
+**Solution**: Clear old entries or reset:
+```bash
+rm config/streaming_cache.json
+```
+
+### Git wants to commit cache file
+**Check**: Is it in `.gitignore`?
+```bash
+grep "streaming_cache.json" .gitignore
+```
+
+If missing, add it:
+```bash
+echo "config/streaming_cache.json" >> .gitignore
+```
+
+### Cache seems corrupted
+**Solution**: Delete and let it regenerate:
+```bash
+rm config/streaming_cache.json
+# Run streaming search - cache will be recreated
+```
+
+## Performance Impact
+
+**Cache file size vs. performance:**
+- 1-5 MB: Normal, good performance
+- 5-10 MB: Still fine, consider occasional cleanup
+- 10-20 MB: Large but functional, cleanup recommended
+- 20+ MB: Clean up old entries to improve load time
+
+**JSON parsing time:**
+- Small (1 MB): <0.1 seconds
+- Medium (5 MB): ~0.2-0.5 seconds
+- Large (10 MB): ~0.5-1 second
+- Very large (20+ MB): >1 second
+
+For most use cases, even a 10MB cache loads quickly and saves minutes of API calls.
+
+---
+
+*Last updated: October 2025*

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -1,0 +1,219 @@
+# Implementation Summary: Division Filtering & Apple Music Album Search Caching
+
+## Overview
+This implementation adds two major features to the streaming search script:
+1. **Division Filtering**: Filter processing to specific divisions using simplified codes (E, 1-7)
+2. **Apple Music Album Search Caching**: Cache album search results to reduce API rate limiting
+
+## Changes Made
+
+### 1. Division Filtering
+
+#### New Constant: `DIVISION_CODE_MAP`
+```python
+DIVISION_CODE_MAP = {
+    "E": "Elite",
+    "1": "1. divisjon",
+    "2": "2. divisjon",
+    "3": "3. divisjon",
+    "4": "4. divisjon",
+    "5": "5. divisjon",
+    "6": "6. divisjon",
+    "7": "7. divisjon",
+}
+```
+
+#### New Function: `parse_divisions_argument()`
+- Location: `src/nmjanitsjar_scraper/streaming_search.py` (around line 1299)
+- Validates and converts division codes to full division names
+- Accepts both codes (E, 1-7) and full names ("Elite", "1. divisjon", etc.)
+- Deduplicates while preserving order
+- Raises `ValueError` for invalid codes
+
+#### CLI Argument: `--divisions`
+- Accepts one or more division codes
+- Example: `--divisions E 1 2` processes Elite, 1. divisjon, and 2. divisjon only
+- If omitted, all divisions are processed (backward compatible)
+
+#### Filtering Logic
+- Added to `generate_streaming_links()` function
+- Filters performances during year_map construction
+- Logs which divisions are being processed when filter is active
+
+### 2. Apple Music Album Search Caching
+
+#### StreamingCache Enhancements
+**Data Structure** (line ~278):
+```python
+{
+  "apple": {
+    "album_tracks": { ... },  # existing
+    "album_searches": {        # NEW
+      "2023|2. divisjon": {
+        "albums": [...],
+        "fetched_at": 1690000000.0
+      }
+    }
+  }
+}
+```
+
+**New Methods**:
+- `get_apple_album_search(year, division)` - Retrieve cached album search results
+- `set_apple_album_search(year, division, albums)` - Store album search results
+
+#### Caching Logic in `_get_apple_tracks_for_division()`
+1. **Cache Check** (year >= 2012 only):
+   - Checks cache before making any API calls
+   - Logs cache HIT with album count
+
+2. **Cache Miss Flow**:
+   - Performs normal album searches
+   - Handles 403/404 errors gracefully (rate limiting)
+   - Deduplicates albums by collectionId
+
+3. **Cache Write**:
+   - Stores results only for years >= 2012
+   - Only caches non-empty results
+   - Logs cache WRITE with album count
+
+#### Why Years >= 2012?
+- Albums from 2012 onwards are division-specific
+- Earlier albums are "collection albums" with mixed content
+- Prevents cache pollution with irrelevant data
+
+### 3. Logging Improvements
+- `[apple] Album search cache HIT for {year}|{division} ({count} albums)`
+- `[apple] Album search cache WRITE for {year}|{division} ({count} albums)`
+- `[apple] Search failed for '{term}' (rate limited or not found), continuing...`
+- `[cyan]Processing divisions: {division_list}[/cyan]`
+
+## Usage Examples
+
+### Process a Single Division
+```bash
+python -m src.nmjanitsjar_scraper.streaming_search \
+  --positions apps/band-positions/public/data/band_positions.json \
+  --output-dir apps/band-positions/public/data/streaming \
+  --aggregate apps/band-positions/public/data/piece_streaming_links.json \
+  --years 2023 \
+  --divisions 2 \
+  --min-year 2012 \
+  --band-type wind \
+  --credentials config/streaming_credentials.json \
+  --overrides config/streaming_overrides.json \
+  --cache config/streaming_cache.json
+```
+
+### Process Multiple Divisions
+```bash
+python -m src.nmjanitsjar_scraper.streaming_search \
+  --positions apps/band-positions/public/data/band_positions.json \
+  --output-dir apps/band-positions/public/data/streaming \
+  --aggregate apps/band-positions/public/data/piece_streaming_links.json \
+  --years 2023 \
+  --divisions E 1 2 3 \
+  --min-year 2012 \
+  --band-type wind \
+  --credentials config/streaming_credentials.json \
+  --overrides config/streaming_overrides.json \
+  --cache config/streaming_cache.json
+```
+
+### Process All Divisions (Default Behavior)
+```bash
+python -m src.nmjanitsjar_scraper.streaming_search \
+  --positions apps/band-positions/public/data/band_positions.json \
+  --output-dir apps/band-positions/public/data/streaming \
+  --aggregate apps/band-positions/public/data/piece_streaming_links.json \
+  --years 2023 \
+  --min-year 2012 \
+  --band-type wind \
+  --credentials config/streaming_credentials.json \
+  --overrides config/streaming_overrides.json \
+  --cache config/streaming_cache.json
+```
+
+## Benefits
+
+### 1. Reduced API Traffic
+- **Before**: Every run searches Apple Music for all albums across all search terms
+- **After**: Subsequent runs for the same year/division use cached results
+- **Impact**: Dramatically reduces 403 Forbidden rate limit errors
+
+### 2. Faster Processing
+- Cache hits are instant (no network latency)
+- Especially beneficial when re-running after errors or for fixes
+
+### 3. Targeted Processing
+- Fix a single missing link without processing all 8 divisions
+- Test changes on a subset of divisions
+- Reduces load on both Spotify and Apple Music APIs
+
+### 4. Backward Compatible
+- Omitting `--divisions` processes all divisions as before
+- Existing cache files work seamlessly (backward compatible structure)
+- No breaking changes to existing workflows
+
+## Cache Management
+
+### Viewing Cache Contents
+```bash
+cat config/streaming_cache.json | jq '.apple.album_searches'
+```
+
+### Clearing Cache for a Specific Year/Division
+Edit `config/streaming_cache.json` and remove the specific key:
+```json
+{
+  "apple": {
+    "album_searches": {
+      "2023|2. divisjon": { ... }  // Remove this entry
+    }
+  }
+}
+```
+
+### Full Cache Reset
+Delete or backup the cache file:
+```bash
+mv config/streaming_cache.json config/streaming_cache.json.bak
+```
+
+## Testing Recommendations
+
+1. **Test Single Division**:
+   - Run with `--divisions 2` for 2023
+   - Verify only "2. divisjon" is processed
+   - Check for cache WRITE messages
+
+2. **Test Cache Hit**:
+   - Re-run the same command
+   - Verify cache HIT messages appear
+   - Confirm no Apple Music API calls are made
+
+3. **Test Invalid Code**:
+   - Run with `--divisions 9`
+   - Verify helpful error message
+
+4. **Test Pre-2012 Year**:
+   - Run with `--years 2011`
+   - Verify cache is NOT used (no HIT/WRITE messages)
+
+5. **Test Backward Compatibility**:
+   - Run without `--divisions` argument
+   - Verify all divisions are processed
+
+## Known Limitations
+
+1. **Year Restriction**: Script still requires single year processing (`len(target_years) == 1`)
+2. **Cache Invalidation**: No automatic cache expiration (manual management required)
+3. **Spotify**: Album search caching not yet implemented for Spotify (only Apple Music)
+
+## Future Enhancements
+
+1. Consider adding Spotify album search caching
+2. Add cache expiration/TTL mechanism
+3. Add `--clear-cache` CLI option
+4. Support multi-year processing with division filter
+5. Add cache statistics (`--cache-stats`)

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -39,6 +39,10 @@ DIVISION_CODE_MAP = {
 - Added to `generate_streaming_links()` function
 - Filters performances during year_map construction
 - Logs which divisions are being processed when filter is active
+- **Incremental updates**: When using `--divisions`, existing entries from other divisions are preserved
+  - The script merges new entries with existing ones
+  - Only entries for the specified divisions are replaced
+  - Example: `--divisions 2` updates only "2. divisjon" while keeping Elite, 1, 3-7 intact
 
 ### 2. Apple Music Album Search Caching
 
@@ -133,6 +137,36 @@ python -m src.nmjanitsjar_scraper.streaming_search \
   --overrides config/streaming_overrides.json \
   --cache config/streaming_cache.json
 ```
+
+## Important: Division Filter Behavior
+
+⚠️ **Incremental Updates (Fixed)**
+
+When using `--divisions`, the script now **merges** entries instead of overwriting:
+
+**Before the fix** (❌ Bug):
+```bash
+# Running this would DELETE all other divisions!
+--divisions 2  # Would remove Elite, 1, 3-7 from 2023.json
+```
+
+**After the fix** (✅ Correct):
+```bash
+# Running this preserves other divisions
+--divisions 2  # Only updates 2. divisjon, keeps all others
+```
+
+**How it works:**
+1. Loads existing year file (e.g., `2023.json`)
+2. Removes entries for filtered divisions (e.g., "2. divisjon")
+3. Adds new entries for those divisions
+4. Merges and sorts all entries
+5. Saves back to file
+
+**Use cases:**
+- Fix a single missing link: `--divisions 3`
+- Update multiple divisions: `--divisions 1 2 3`
+- Complete refresh: Omit `--divisions` (processes all)
 
 ## Benefits
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,35 @@ poetry install
 pip install -r requirements.txt
 ```
 
+## Configuration
+
+### Streaming Link Discovery (Optional)
+
+If you want to use the streaming link discovery feature for Spotify and Apple Music:
+
+1. **Create credentials file** (required for Spotify):
+   ```bash
+   cp config/streaming_credentials.json.example config/streaming_credentials.json
+   ```
+   Then edit `config/streaming_credentials.json` with your Spotify API credentials.
+
+2. **Cache file setup** (automatic):
+   - The cache file `config/streaming_cache.json` is created automatically on first run
+   - This file is **not tracked in git** (machine-specific, can grow to 8+ MB)
+   - If needed, you can create it manually:
+     ```bash
+     cp config/streaming_cache.json.example config/streaming_cache.json
+     ```
+
+3. **Cache management**:
+   - View cache contents: `cat config/streaming_cache.json | jq '.apple.album_searches'`
+   - Clear specific entries: Edit the JSON file and remove unwanted keys
+   - Full reset: `rm config/streaming_cache.json` (will be recreated on next run)
+
+**Note**: The cache significantly reduces API rate limiting by storing:
+- Album track listings (Spotify & Apple Music)
+- Album search results (Apple Music only, for years ≥ 2012)
+
 ## Quick Start
 
 ### Run Complete Pipeline

--- a/apps/band-positions/public/data/piece_streaming_links.json
+++ b/apps/band-positions/public/data/piece_streaming_links.json
@@ -5383,62 +5383,362 @@
     {
       "year": 2016,
       "division": "1. divisjon",
+      "band": "Borge Musikkorps",
+      "result_piece": "Cheetah",
+      "recording_title": "Cheetah",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/0PukZLpxJOyuO085F456BB",
+      "apple_music": "https://music.apple.com/us/album/cheetah/1095046265?i=1095046594&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Borge Musikkorps",
+      "result_piece": "Theme and Variations for Wind Band, Op. 43a",
+      "recording_title": "Theme and Variations",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/4FFAjKdfilkDQNYoMa45cL",
+      "apple_music": "https://music.apple.com/us/album/theme-and-variations/1095046265?i=1095046595&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Byneset Musikkorps",
+      "result_piece": "Homenaje a Joaquìn Sorolla Cuados Sinfònicos",
+      "recording_title": "Homenaje a Joaquin Sorolla - Byneset",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/7CtEys5Mf7J1uXGbvAFWy9",
+      "apple_music": "https://music.apple.com/us/album/homenaje-a-joaquin-sorolla-byneset/1095046265?i=1095046596&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Drammen Konsertorkester",
+      "result_piece": "Symphonic Metamorphosis of themes by Carl Maria von Weber",
+      "recording_title": "Symphonic Metamorphosis on Themes by Carl Maria von Weber",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/3RPTAxmoWal70UaOio3C33",
+      "apple_music": "https://music.apple.com/us/album/symphonic-metamorphosis-on-themes-by-carl-maria-von-weber/1095046265?i=1095046640&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Kolbotn Konsertorkester",
+      "result_piece": "Breaking Another Wall",
+      "recording_title": "Breaking Another Wall",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/1qvyHvKbc639A1ftrUivz1",
+      "apple_music": "https://music.apple.com/us/album/breaking-another-wall/1095046265?i=1095046651&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Kolbotn Konsertorkester",
+      "result_piece": "Lux Aurumque",
+      "recording_title": "Lux Aurumque",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/5naEyEChaeOcYmWnhFAFQy",
+      "apple_music": "https://music.apple.com/us/album/lux-aurumque/1095046265?i=1095046652&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Lisleby Musikkorps",
+      "result_piece": "Konzertmusik Für Blasorchester",
+      "recording_title": "Konzertmusik Für Blasorchester",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/3nSPioiaKL12He375iDDUP",
+      "apple_music": "https://music.apple.com/us/album/konzertmusik-f%C3%BCr-blasorchester/1095046265?i=1095046591&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
       "band": "Lisleby Musikkorps",
       "result_piece": "Overture on a March",
-      "recording_title": "Overture to a New Age",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age/1112522030?i=1112523078&uo=4"
+      "recording_title": "Overture on a March",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/4distdOwwwHTlTGcgEH9jm",
+      "apple_music": "https://music.apple.com/us/album/overture-on-a-march/1095046265?i=1095046587&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Lørenskog Musikkorps",
+      "result_piece": "Danzón no. 2",
+      "recording_title": "Danzón no. 2",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/4lVfByi0Th9RU68DHKBfjg",
+      "apple_music": "https://music.apple.com/us/album/danz%C3%B3n-no-2/1095046265?i=1095046644&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Lørenskog Musikkorps",
+      "result_piece": "Sketches on a Tudor Psalm",
+      "recording_title": "Sketches on a Tudor Psalm",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/4i8MpJj44XO7tZGyTlHUcU",
+      "apple_music": "https://music.apple.com/us/album/sketches-on-a-tudor-psalm/1095046265?i=1095046643&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Mo Hornmusikk",
+      "result_piece": "Homenaje a Joaquìn Sorolla Cuados Sinfònicos",
+      "recording_title": "Homenaje a Joaquin Sorolla - Mo",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/17d33SDVl1TmD2I6r0AzAB",
+      "apple_music": "https://music.apple.com/us/album/homenaje-a-joaquin-sorolla-mo/1095046265?i=1095046638&uo=4"
     },
     {
       "year": 2016,
       "division": "1. divisjon",
       "band": "Nittedal og Hakadal Janitsjar",
       "result_piece": "Symfoni nr. 1, 3. og 4. sats",
-      "recording_title": "Feste Romane 1-3. og 4.sats",
-      "album": "Nm Janitsjar 2016 - Elitedivisjon",
-      "spotify": "https://open.spotify.com/track/53xRczY3O9yYR8OvKKbQo1",
-      "apple_music": "https://music.apple.com/us/album/feste-romane-1-3-og-4-sats/1095045689?i=1095046031&uo=4"
+      "recording_title": "Symfoni nr. 1, 3 og 4 sats",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/0fYhXcQQN4kCrJPcghWvcm",
+      "apple_music": "https://music.apple.com/us/album/symfoni-nr-1-3-og-4-sats/1095046265?i=1095046732&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Nittedal og Hakadal Janitsjar",
+      "result_piece": "Trista",
+      "recording_title": "Trista",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/1cxzvGSKMQXeOwVkWNhtk4",
+      "apple_music": "https://music.apple.com/us/album/trista/1095046265?i=1095046729&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Sandefjord Musikkorps",
+      "result_piece": "The Soul has Many Motions",
+      "recording_title": "The Soul has Many Motions",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/5LeM8amG1FzvYVxYtvFH6q",
+      "apple_music": "https://music.apple.com/us/album/the-soul-has-many-motions/1095046265?i=1095046649&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Skjold Nesttun Janitsjar",
+      "result_piece": "Pinocchio",
+      "recording_title": "Pinocchio",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/7C7iLlyp4oTpdJ7JU3a6tR",
+      "apple_music": "https://music.apple.com/us/album/pinocchio/1095046265?i=1095046724&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Stavanger Musikkorps av 1919",
+      "result_piece": "Angels in the Architecture",
+      "recording_title": "Angels in the Architecture",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/1w1BtH9JzeGyf8ec7Y13Ik",
+      "apple_music": "https://music.apple.com/us/album/angels-in-the-architecture/1095046265?i=1095046631&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Stavanger Musikkorps av 1919",
+      "result_piece": "Gloriosa, 1. sats",
+      "recording_title": "Gloriosa, 1.sats",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/1Z457phJJvHmNfODraHIuo",
+      "apple_music": "https://music.apple.com/us/album/gloriosa-1-sats/1095046265?i=1095046597&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Strusshamn Musikkforening",
+      "result_piece": "Jungla, Poema ambientado en la Selva Africana",
+      "recording_title": "Jungla, Poema ambientado",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/0pL8ogUWLWXrAYwFRZBGFM",
+      "apple_music": "https://music.apple.com/us/album/jungla-poema-ambientado/1095046265?i=1095046728&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Strusshamn Musikkforening",
+      "result_piece": "La promenade, La Femme a l’ombrelle",
+      "recording_title": "La promenada. La femme a l´ombrelle",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/5wnfz2HJveKT1KGqEExdTG",
+      "apple_music": "https://music.apple.com/us/album/la-promenada-la-femme-a-lombrelle/1095046265?i=1095046727&uo=4"
     },
     {
       "year": 2016,
       "division": "1. divisjon",
       "band": "Vestsidens Musikkorps",
       "result_piece": "Symphony no. 2",
-      "recording_title": "Symphony no. 7",
-      "album": "Nm Janitsjar 2016 - Elitedivisjon",
-      "spotify": "https://open.spotify.com/track/5uv8N6hCCPZp8jEUIZjTTy",
-      "apple_music": "https://music.apple.com/us/album/symphony-no-7/1095045689?i=1095046057&uo=4"
+      "recording_title": "Symphony no. 2",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/6tw0gp37bbL3mm4nxMOoOV",
+      "apple_music": "https://music.apple.com/us/album/symphony-no-2/1095046265?i=1095046648&uo=4"
     },
     {
       "year": 2016,
       "division": "2. divisjon",
       "band": "Aalesunds Ungdomsmusikkorps",
       "result_piece": "Children of Gala",
-      "recording_title": "Children of Sanchez",
-      "album": "Nm Janitsjar 2016 - 7.Divisjon",
-      "spotify": "https://open.spotify.com/track/4qoIc6iD2ZhW6LuSUJcIIA",
-      "apple_music": null
+      "recording_title": "Children of Gala",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/children-of-gala/1095042036?i=1095042393&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Aalesunds Ungdomsmusikkorps",
+      "result_piece": "Dusk",
+      "recording_title": "Dusk",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/dusk/1095042036?i=1095042395&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Aalesunds Ungdomsmusikkorps",
+      "result_piece": "O Waly, Waly",
+      "recording_title": "O Waly, Waly",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/o-waly-waly/1095042036?i=1095042431&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Alvøens Musikkforening",
+      "result_piece": "Paris Sketches",
+      "recording_title": "Paris Sketches - Alvøens",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/paris-sketches-alv%C3%B8ens/1095042036?i=1095042507&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Arendal Byorkester",
+      "result_piece": "Abide With Me",
+      "recording_title": "Abide With Me",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/abide-with-me/1095042036?i=1095042511&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Arendal Byorkester",
+      "result_piece": "Die Fledermaus, Overture",
+      "recording_title": "Die Fledermaus: Overture",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/die-fledermaus-overture/1095042036?i=1095042508&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Arendal Byorkester",
+      "result_piece": "Festmarsj",
+      "recording_title": "Festmarsj",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/festmarsj/1095042036?i=1095042510&uo=4"
     },
     {
       "year": 2016,
       "division": "2. divisjon",
       "band": "Bispehaugen Ungdomskorps",
       "result_piece": "Arabesque",
-      "recording_title": "Arabesque",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
+      "recording_title": "Arabesque - Bispehaugen",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
       "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/arabesque/1110700233?i=1110701789&uo=4"
+      "apple_music": "https://music.apple.com/us/album/arabesque-bispehaugen/1095042036?i=1095042504&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Bispehaugen Ungdomskorps",
+      "result_piece": "Pinocchio",
+      "recording_title": "Pinocchio",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/pinocchio/1095042036?i=1095042500&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Bjølsen Ungdomskorps",
+      "result_piece": "Danceries",
+      "recording_title": "Danceries",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/danceries/1095042036?i=1095042499&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Gjøvik Bykorps",
+      "result_piece": "Sunrise at Angel`s Gate",
+      "recording_title": "Sunrise at Angel's Gate",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/sunrise-at-angels-gate/1095042036?i=1095042389&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Gjøvik Bykorps",
+      "result_piece": "Symphonic Moment",
+      "recording_title": "Symphonic Moment",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/symphonic-moment/1095042036?i=1095042390&uo=4"
     },
     {
       "year": 2016,
       "division": "2. divisjon",
       "band": "Halsen Musikkforening",
       "result_piece": "Third Suite for Band (Scenes de Ballet)",
-      "recording_title": "Second Suite for Band",
+      "recording_title": "First Suite for Band, 1 sats",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/3J8lUZlqbHqGE0cXQisHAN",
-      "apple_music": "https://music.apple.com/us/album/second-suite-for-band/1112522030?i=1112523095&uo=4"
+      "spotify": "https://open.spotify.com/track/27QT3DSLus2ONcL93K2LQq",
+      "apple_music": "https://music.apple.com/us/album/third-suite-for-band/1095042036?i=1095042432&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Hov Musikkorps",
+      "result_piece": "Fantasy Variations on a Theme by Niccolo Paganini",
+      "recording_title": "Fantasy Variations on a Theme by Nicco Paganini",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/fantasy-variations-on-a-theme-by-nicco-paganini/1095042036?i=1095042492&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Sagene Janitsjarkorps",
+      "result_piece": "Blue Shades",
+      "recording_title": "Blues Shades",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/blues-shades/1095042036?i=1095042433&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Sagene Janitsjarkorps",
+      "result_piece": "The Year of the Dragon, 2. sats",
+      "recording_title": "The Year of the Dragon, 2.sats",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/the-year-of-the-dragon-2-sats/1095042036?i=1095042441&uo=4"
     },
     {
       "year": 2016,
@@ -5446,19 +5746,99 @@
       "band": "Sande Musikkorps",
       "result_piece": "Saga Candida",
       "recording_title": "Saga Candida",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
       "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/saga-candida/1110700233?i=1110701733&uo=4"
+      "apple_music": "https://music.apple.com/us/album/saga-candida/1095042036?i=1095042456&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Sinsen Konsertorkester",
+      "result_piece": "From Ancient Times",
+      "recording_title": "From Ancient Times",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/from-ancient-times/1095042036?i=1095042566&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Stabekk Janitsjarorkester",
+      "result_piece": "Det gamle kvernhuset",
+      "recording_title": "Det Gamle Kvernhuset",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/det-gamle-kvernhuset/1095042036?i=1095042452&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Stabekk Janitsjarorkester",
+      "result_piece": "Fanfare and Scherzo",
+      "recording_title": "Fanfare and Scherzo",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/fanfare-and-scherzo/1095042036?i=1095042449&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Stabekk Janitsjarorkester",
+      "result_piece": "Symphonic Movement",
+      "recording_title": "Symphonic Movement",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/symphonic-movement/1095042036?i=1095042455&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Sykkylven Janitsjarorkester",
+      "result_piece": "Paris Sketches",
+      "recording_title": "Paris Sketches - Sykkylven",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/paris-sketches-sykkylven/1095042036?i=1095042494&uo=4"
     },
     {
       "year": 2016,
       "division": "2. divisjon",
       "band": "Tromsø Orkesterforenings Janitsjarkorps",
       "result_piece": "Arabesque",
-      "recording_title": "Arabesque",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
+      "recording_title": "Arabesque - Tromsø",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
       "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/arabesque/1110700233?i=1110701789&uo=4"
+      "apple_music": "https://music.apple.com/us/album/arabesque-troms%C3%B8/1095042036?i=1095042567&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Tromsø Orkesterforenings Janitsjarkorps",
+      "result_piece": "Scootin' on Hardrock",
+      "recording_title": "Scootin'on Hardrock",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/scootinon-hardrock/1095042036?i=1095042573&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Tønsberg Janitsjarkorps",
+      "result_piece": "Symphony for Wind Orchestra",
+      "recording_title": "Symphony for Wind Orchestra - Montage",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/symphony-for-wind-orchestra-montage/1095042036?i=1095042448&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Ådalsbruk Musikkforening",
+      "result_piece": "Journey to the Centre of the Earth",
+      "recording_title": "Journey to the Centre of the Earth",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/journey-to-the-centre-of-the-earth/1095042036?i=1095042497&uo=4"
     },
     {
       "year": 2016,
@@ -5466,8 +5846,8 @@
       "band": "Asker Musikkorps",
       "result_piece": "Hispanola",
       "recording_title": "Hispaniola",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/25oA4mxTnlwAYUCoHAkHyj",
       "apple_music": "https://music.apple.com/us/album/hispaniola/1110700233?i=1110701782&uo=4"
     },
     {
@@ -5476,8 +5856,8 @@
       "band": "Asker og Bærum Ungdomskorps",
       "result_piece": "Saga Candida",
       "recording_title": "Saga Candida",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/1QYLO8H8VfOAooVmw1eXOJ",
       "apple_music": "https://music.apple.com/us/album/saga-candida/1110700233?i=1110701733&uo=4"
     },
     {
@@ -5486,8 +5866,8 @@
       "band": "Bodø Harmonimusikk",
       "result_piece": "Bandancing",
       "recording_title": "Bandancing",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/3EKicSYin9Ics1A7PaoKyg",
       "apple_music": "https://music.apple.com/us/album/bandancing/1110700233?i=1110701779&uo=4"
     },
     {
@@ -5495,9 +5875,9 @@
       "division": "3. divisjon",
       "band": "Fåberg Musikkforening",
       "result_piece": "The Seasons",
-      "recording_title": "Sea Songs",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/2BKTd4747sVXce3E3ySJKS",
+      "recording_title": "The Seasons",
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/6e6lc2BrUn8kX1drHED5pI",
       "apple_music": "https://music.apple.com/us/album/the-seasons/1110700233?i=1110701775&uo=4"
     },
     {
@@ -5506,8 +5886,8 @@
       "band": "Heimdal Musikkorps",
       "result_piece": "Arabesque",
       "recording_title": "Arabesque",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/6i6QsPa8T4yv6G3GSFdcD9",
       "apple_music": "https://music.apple.com/us/album/arabesque/1110700233?i=1110701789&uo=4"
     },
     {
@@ -5515,10 +5895,10 @@
       "division": "3. divisjon",
       "band": "Heimdal Musikkorps",
       "result_piece": "Evolutions",
-      "recording_title": "Evolutions",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/evolutions/1110700233?i=1110701788&uo=4"
+      "recording_title": "Foundation",
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/6LaTAwRAnlR0qeatWCHd2U",
+      "apple_music": "https://music.apple.com/us/album/foundation/1110700233?i=1110701781&uo=4"
     },
     {
       "year": 2016,
@@ -5526,8 +5906,8 @@
       "band": "Hovin Musikkorps",
       "result_piece": "Foundation",
       "recording_title": "Foundation",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/6LaTAwRAnlR0qeatWCHd2U",
       "apple_music": "https://music.apple.com/us/album/foundation/1110700233?i=1110701781&uo=4"
     },
     {
@@ -5536,8 +5916,8 @@
       "band": "Lungegaardens Musikkorps",
       "result_piece": "Armenian Dances, Part 1",
       "recording_title": "Armenian Dances, Pt. 1",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/7E6o4l230iM6eaHXAPGvxD",
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/2JmwKHl9sG5D384nHZ3tLy",
       "apple_music": "https://music.apple.com/us/album/armenian-dances-part-1/1110700233?i=1110701783&uo=4"
     },
     {
@@ -5545,9 +5925,9 @@
       "division": "3. divisjon",
       "band": "Melhus Janitsjarkorps",
       "result_piece": "Music for Life",
-      "recording_title": "Music for a festival",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/6d6hiK8fiIAz1FyXFjtp9R",
+      "recording_title": "Music for Life",
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/2WifILblema52Th4vCbcqq",
       "apple_music": "https://music.apple.com/us/album/music-for-life/1110700233?i=1110701774&uo=4"
     },
     {
@@ -5556,8 +5936,8 @@
       "band": "Melhus Janitsjarkorps",
       "result_piece": "Perthshire Majesty",
       "recording_title": "Perthshire Majesty",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/7EYhvUVkcRPLObGruaNkXV",
       "apple_music": "https://music.apple.com/us/album/perthshire-majesty/1110700233?i=1110701773&uo=4"
     },
     {
@@ -5566,8 +5946,8 @@
       "band": "Oppegård Janitsjar",
       "result_piece": "Variations on a Theme of Robert Schumann (\"The Happy Farmer\")",
       "recording_title": "Variations on a Theme of Robert Schumann",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/7q2VAJh9Sfv5IYAJiZ2ywB",
       "apple_music": "https://music.apple.com/us/album/variations-on-a-theme-of-robert-schumann/1110700233?i=1110701787&uo=4"
     },
     {
@@ -5576,8 +5956,8 @@
       "band": "Os Musikkforening",
       "result_piece": "Corsican Litany",
       "recording_title": "Corsican Litany",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/0sYk7iIOohiMhA2WGESixy",
       "apple_music": "https://music.apple.com/us/album/corsican-litany/1110700233?i=1110701735&uo=4"
     },
     {
@@ -5586,8 +5966,8 @@
       "band": "Os Musikkforening",
       "result_piece": "Hjalarljod",
       "recording_title": "Hjalarljod",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/2jC4L9oLstfV1hJCVzCFA4",
       "apple_music": "https://music.apple.com/us/album/hjalarljod/1110700233?i=1110701734&uo=4"
     },
     {
@@ -5596,8 +5976,8 @@
       "band": "Oslo Postorkester",
       "result_piece": "The Saga of Haakon the Good",
       "recording_title": "Tha Saga of Haakon the Good",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/2y9K1h0cTzdbKdW3sPbVMt",
       "apple_music": "https://music.apple.com/us/album/tha-saga-of-haakon-the-good/1110700233?i=1110701732&uo=4"
     },
     {
@@ -5606,9 +5986,19 @@
       "band": "Ranheim Musikkforening",
       "result_piece": "October",
       "recording_title": "October",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/7w8m8O8DmrR71D8D3w9iDU",
       "apple_music": "https://music.apple.com/us/album/october/1110700233?i=1110701737&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "3. divisjon",
+      "band": "Ranheim Musikkforening",
+      "result_piece": "Wild Nights!",
+      "recording_title": "Wild Nights",
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/3DnmDeQvOExc5tM3YZ4wmc",
+      "apple_music": "https://music.apple.com/us/album/wild-nights/1110700233?i=1110701738&uo=4"
     },
     {
       "year": 2016,
@@ -5616,8 +6006,8 @@
       "band": "Skedsmo Janitsjarorkester",
       "result_piece": "Sacred Harp",
       "recording_title": "Sacred Harp",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/4yuc1un2d4u0j00S4pdEG6",
       "apple_music": "https://music.apple.com/us/album/sacred-harp/1110700233?i=1110701772&uo=4"
     },
     {
@@ -5626,8 +6016,8 @@
       "band": "Skedsmo Janitsjarorkester",
       "result_piece": "Seven Hills Overture",
       "recording_title": "Seven Hills Overture",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/21hvNHGfZAENkYNx8ByjG8",
       "apple_music": "https://music.apple.com/us/album/seven-hills-overture/1110700233?i=1110701739&uo=4"
     },
     {
@@ -5636,8 +6026,8 @@
       "band": "Strindheim Janitsjar",
       "result_piece": "Incantation and Dance",
       "recording_title": "Incantation and Dance",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/7EXdHSeGvVljzd3GrkZaV4",
       "apple_music": "https://music.apple.com/us/album/incantation-and-dance/1110700233?i=1110701778&uo=4"
     },
     {
@@ -5646,8 +6036,8 @@
       "band": "Strindheim Janitsjar",
       "result_piece": "Mother Earth (A Fanfare)",
       "recording_title": "Mother Earth",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/6HdL4n6N2f8sUlNQppj0Sy",
       "apple_music": "https://music.apple.com/us/album/mother-earth/1110700233?i=1110701776&uo=4"
     },
     {
@@ -5656,8 +6046,8 @@
       "band": "Svolvær Musikkforening",
       "result_piece": "subTERRA",
       "recording_title": "subTERRA",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/33nm5jc1FmZOwxsQTHagIp",
       "apple_music": "https://music.apple.com/us/album/subterra/1110700233?i=1110701780&uo=4"
     },
     {
@@ -5666,9 +6056,9 @@
       "band": "Åsane Musikklag",
       "result_piece": "The Saga of Haakon the Good",
       "recording_title": "Tha Saga of Haakon the Good",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/tha-saga-of-haakon-the-good/1110700233?i=1110701732&uo=4"
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/10mAB8HuwO0YayJ49xdRCE",
+      "apple_music": "https://music.apple.com/us/album/tha-saga-of-haakon-the-good/1110700233?i=1110701736&uo=4"
     },
     {
       "year": 2016,
@@ -5688,7 +6078,7 @@
       "recording_title": "Music for a festival",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
       "spotify": "https://open.spotify.com/track/6d6hiK8fiIAz1FyXFjtp9R",
-      "apple_music": "https://music.apple.com/us/album/music-for-a-solemnity/1112522030?i=1112523076&uo=4"
+      "apple_music": "https://music.apple.com/us/album/music-for-life/1110700233?i=1110701774&uo=4"
     },
     {
       "year": 2016,
@@ -5708,7 +6098,7 @@
       "recording_title": "Overture Allemande",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
       "spotify": "https://open.spotify.com/track/3aYpyT9cPUjdOBaCooKM4a",
-      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age/1112522030?i=1112523078&uo=4"
+      "apple_music": null
     },
     {
       "year": 2016,
@@ -5748,7 +6138,7 @@
       "recording_title": "Sea Songs",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
       "spotify": "https://open.spotify.com/track/2BKTd4747sVXce3E3ySJKS",
-      "apple_music": "https://music.apple.com/us/album/the-seasons/1110700233?i=1110701775&uo=4"
+      "apple_music": null
     },
     {
       "year": 2016,
@@ -5788,7 +6178,17 @@
       "recording_title": "First Suite for Band, 1 sats",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
       "spotify": "https://open.spotify.com/track/27QT3DSLus2ONcL93K2LQq",
-      "apple_music": "https://music.apple.com/us/album/second-suite-for-band/1112522030?i=1112523095&uo=4"
+      "apple_music": null
+    },
+    {
+      "year": 2016,
+      "division": "4. divisjon",
+      "band": "Musikkforeningen Viken",
+      "result_piece": "Så skimrande var aldrig havet",
+      "recording_title": "First Suite for Band, 1 sats",
+      "album": "Nm Janitsjar 2016 - 4.Divisjon",
+      "spotify": "https://open.spotify.com/track/27QT3DSLus2ONcL93K2LQq",
+      "apple_music": null
     },
     {
       "year": 2016,
@@ -5815,9 +6215,9 @@
       "division": "4. divisjon",
       "band": "Nes Janitsjarkorps",
       "result_piece": "Machu Picchu - City in the sky - the mystery of the hidden sun Temple",
-      "recording_title": "Machu Picchu City in the Sky",
+      "recording_title": "Machu Picchu City in the Sky - Nes",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/6DsEB9csmUxNF21GpmXTww",
+      "spotify": "https://open.spotify.com/track/4gRSixW9cREpezx8fvDZGE",
       "apple_music": null
     },
     {
@@ -5825,10 +6225,10 @@
       "division": "4. divisjon",
       "band": "Prosjekt MMXIX",
       "result_piece": "Armenian Dances, Part 1",
-      "recording_title": "Armenian Dances, Pt. 1",
+      "recording_title": "Armenian Dances",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/7E6o4l230iM6eaHXAPGvxD",
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-part-1/1110700233?i=1110701783&uo=4"
+      "spotify": "https://open.spotify.com/track/14DiFKscGosAw675PU7FOX",
+      "apple_music": null
     },
     {
       "year": 2016,
@@ -5848,7 +6248,7 @@
       "recording_title": "Banja Luka",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
       "spotify": "https://open.spotify.com/track/786Pbi5MonjqUzKm0fDOBG",
-      "apple_music": "https://music.apple.com/us/album/banja-luka/1112522030?i=1112523040&uo=4"
+      "apple_music": null
     },
     {
       "year": 2016,
@@ -5875,10 +6275,10 @@
       "division": "4. divisjon",
       "band": "Tvedestrand Musikkorps",
       "result_piece": "Second Suite in F for Military Band",
-      "recording_title": "First Suite in Eb for Military Band",
-      "album": "Nm Janitsjar 2016 - 7.Divisjon",
-      "spotify": "https://open.spotify.com/track/2oEovqafFDvwHFREZdcqgt",
-      "apple_music": "https://music.apple.com/us/album/second-suite-for-band/1112522030?i=1112523095&uo=4"
+      "recording_title": "Second Suite in F Major",
+      "album": "Nm Janitsjar 2016 - 4.Divisjon",
+      "spotify": "https://open.spotify.com/track/7hHRgPOt6P8mxHk1i1hup5",
+      "apple_music": null
     },
     {
       "year": 2016,
@@ -5888,7 +6288,7 @@
       "recording_title": "Second Suite for Band",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
       "spotify": "https://open.spotify.com/track/3J8lUZlqbHqGE0cXQisHAN",
-      "apple_music": "https://music.apple.com/us/album/second-suite-for-band/1112522030?i=1112523095&uo=4"
+      "apple_music": null
     },
     {
       "year": 2016,
@@ -5906,8 +6306,8 @@
       "band": "Alvdal-Tynset Janitsjarkorps",
       "result_piece": "Dies Infernus",
       "recording_title": "Dies Infernus",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/0BXrUy82ID3d7TXx6LW8aP",
       "apple_music": "https://music.apple.com/us/album/dies-infernus/1112522030?i=1112523098&uo=4"
     },
     {
@@ -5916,8 +6316,8 @@
       "band": "Alvdal-Tynset Janitsjarkorps",
       "result_piece": "Hennepin County Dawn",
       "recording_title": "Hennepin County Dawn",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/5RSCQQPm4hyqTmay8ZroWk",
       "apple_music": "https://music.apple.com/us/album/hennepin-county-dawn/1112522030?i=1112523097&uo=4"
     },
     {
@@ -5926,9 +6326,19 @@
       "band": "Alvdal-Tynset Janitsjarkorps",
       "result_piece": "Scramble",
       "recording_title": "Scramble",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/6fupKaJmgMEqSd2PUfMoRc",
       "apple_music": "https://music.apple.com/us/album/scramble/1112522030?i=1112523096&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "5. divisjon",
+      "band": "Bømlo Janitsjar",
+      "result_piece": "Overture to a new Age",
+      "recording_title": "Overture to a New Age",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/7HpvhcKE4MbHdFiiCBOEbY",
+      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age/1112522030?i=1112523078&uo=4"
     },
     {
       "year": 2016,
@@ -5936,8 +6346,8 @@
       "band": "Haugesund Janitsjarorkester",
       "result_piece": "Goddess of Fire",
       "recording_title": "Goddess of Fire",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/246yq0arhhwy1F8E5UXiuF",
       "apple_music": "https://music.apple.com/us/album/goddess-of-fire/1112522030?i=1112523082&uo=4"
     },
     {
@@ -5945,9 +6355,9 @@
       "division": "5. divisjon",
       "band": "Haugesund Janitsjarorkester",
       "result_piece": "Ride",
-      "recording_title": "El Jardin de Las Hespérides",
-      "album": "Nm Janitsjar 2016 - Elitedivisjon",
-      "spotify": "https://open.spotify.com/track/1XfnaO7gm6SowHYM94dWxq",
+      "recording_title": "Ride",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/36HQSUFIkIu8BdfBVBt1K6",
       "apple_music": "https://music.apple.com/us/album/ride/1112522030?i=1112523083&uo=4"
     },
     {
@@ -5956,8 +6366,8 @@
       "band": "Hegra Hornmusikklag",
       "result_piece": "Fra Borge",
       "recording_title": "Fra Borge",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/337hnc63PkuZZp5qkkRFRF",
       "apple_music": "https://music.apple.com/us/album/fra-borge/1112522030?i=1112523112&uo=4"
     },
     {
@@ -5966,8 +6376,8 @@
       "band": "Hegra Hornmusikklag",
       "result_piece": "Persis",
       "recording_title": "Persis",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/5b9WczHc1W5DkjkiqVRnN6",
       "apple_music": "https://music.apple.com/us/album/persis/1112522030?i=1112523109&uo=4"
     },
     {
@@ -5976,8 +6386,8 @@
       "band": "Malvik Musikkorps",
       "result_piece": "Dawn of a New Day",
       "recording_title": "Dawn of a New Day",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/0W4PWYVrRsU3tAOYZy085E",
       "apple_music": "https://music.apple.com/us/album/dawn-of-a-new-day/1112522030?i=1112523080&uo=4"
     },
     {
@@ -5986,8 +6396,8 @@
       "band": "Malvik Musikkorps",
       "result_piece": "Åkernesset",
       "recording_title": "Åkernesset",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/7owMRhOEO8aLtzDpnBBwb3",
       "apple_music": "https://music.apple.com/us/album/%C3%A5kernesset/1112522030?i=1112523079&uo=4"
     },
     {
@@ -5996,8 +6406,8 @@
       "band": "Moss og omegn Janitsjar",
       "result_piece": "Overture Jubiloso",
       "recording_title": "Overture Jubiloso",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/7CaZbHNP5BCEjQmwMLrHSU",
       "apple_music": "https://music.apple.com/us/album/overture-jubiloso/1112522030?i=1112523085&uo=4"
     },
     {
@@ -6005,9 +6415,9 @@
       "division": "5. divisjon",
       "band": "Moss og omegn Janitsjar",
       "result_piece": "Puszta, 1., 2. og 3. sats",
-      "recording_title": "Lincolnshire Posy, 2 og 3 sats",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/5iq7JPAIlS0IEeSoQcBceu",
+      "recording_title": "Putza 1, 2 og 3 sats",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/4eMoyRtNCbp3rZ3XfeuIhd",
       "apple_music": "https://music.apple.com/us/album/putza-1-2-og-3-sats/1112522030?i=1112523084&uo=4"
     },
     {
@@ -6016,8 +6426,8 @@
       "band": "Musikklaget Brage",
       "result_piece": "Pentium",
       "recording_title": "Pentium",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/3VesdAKZZhwir7iAGxY4Xc",
       "apple_music": "https://music.apple.com/us/album/pentium/1112522030?i=1112523099&uo=4"
     },
     {
@@ -6026,8 +6436,8 @@
       "band": "Musikklaget Brage",
       "result_piece": "Vesuvius",
       "recording_title": "Vesuvius",
-      "album": "Nm Janitsjar 2016 - 7.Divisjon",
-      "spotify": "https://open.spotify.com/track/2IZil3bxeI3PIEJHllunsi",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/4cbvUzult5GOl8twqVEX5K",
       "apple_music": "https://music.apple.com/us/album/vesuvius/1112522030?i=1112523105&uo=4"
     },
     {
@@ -6036,8 +6446,8 @@
       "band": "Musikklaget Ulf",
       "result_piece": "Second Suite for Band",
       "recording_title": "Second Suite for Band",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/3J8lUZlqbHqGE0cXQisHAN",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/5WIp1X8EudjnrsXQfHQHrj",
       "apple_music": "https://music.apple.com/us/album/second-suite-for-band/1112522030?i=1112523095&uo=4"
     },
     {
@@ -6046,8 +6456,8 @@
       "band": "Nannestad Janitsjarkorps",
       "result_piece": "Banja Luka",
       "recording_title": "Banja Luka",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/786Pbi5MonjqUzKm0fDOBG",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/7wxb4zAPT98KHlYXw56eS4",
       "apple_music": "https://music.apple.com/us/album/banja-luka/1112522030?i=1112523040&uo=4"
     },
     {
@@ -6056,8 +6466,8 @@
       "band": "Odda Musikklag",
       "result_piece": "Lebuinus ex Daventria",
       "recording_title": "Lebuinus ex Daventria",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/7MJT9mgXrkhPQpdSEkyJ1D",
       "apple_music": "https://music.apple.com/us/album/lebuinus-ex-daventria/1112522030?i=1112523092&uo=4"
     },
     {
@@ -6066,8 +6476,8 @@
       "band": "Ringsaker Janitjsar",
       "result_piece": "Saga Maligna",
       "recording_title": "Saga Maligna",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/2s3nAeL3pfzwYCg1y2Gbvm",
       "apple_music": "https://music.apple.com/us/album/saga-maligna/1112522030?i=1112523113&uo=4"
     },
     {
@@ -6075,9 +6485,9 @@
       "division": "5. divisjon",
       "band": "Stord Musikklag",
       "result_piece": "A Boy’s Dream",
-      "recording_title": "A Boy's Dream",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "recording_title": "A Boy´s Dream",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/1aNc54xftEQu1xg7ZnHFrA",
       "apple_music": "https://music.apple.com/us/album/a-boys-dream/1112522030?i=1112523089&uo=4"
     },
     {
@@ -6086,8 +6496,8 @@
       "band": "Stord Musikklag",
       "result_piece": "Gloriana",
       "recording_title": "Gloriana",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/79Ayk6U2XtIYfNLxh6M07H",
       "apple_music": "https://music.apple.com/us/album/gloriana/1112522030?i=1112523090&uo=4"
     },
     {
@@ -6095,19 +6505,19 @@
       "division": "5. divisjon",
       "band": "Tolga-Os Janitsjar",
       "result_piece": "Banja Luka",
-      "recording_title": "Banja Luka",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/786Pbi5MonjqUzKm0fDOBG",
-      "apple_music": "https://music.apple.com/us/album/banja-luka/1112522030?i=1112523040&uo=4"
+      "recording_title": "Banja Luka - Tolga Os",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/0TI11q8bSl24hlIVLFy1iz",
+      "apple_music": "https://music.apple.com/us/album/banja-luka-tolga-os/1112522030?i=1112523077&uo=4"
     },
     {
       "year": 2016,
       "division": "5. divisjon",
       "band": "Vålerenga Janitsjarkorps",
       "result_piece": "Folk Song Suite for Military Band",
-      "recording_title": "First Suite in Eb for Military Band",
-      "album": "Nm Janitsjar 2016 - 7.Divisjon",
-      "spotify": "https://open.spotify.com/track/2oEovqafFDvwHFREZdcqgt",
+      "recording_title": "Folk Song Suite",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/2JDx9wLkstuFMp6Nvm7N0F",
       "apple_music": "https://music.apple.com/us/album/folk-song-suite/1112522030?i=1112523081&uo=4"
     },
     {
@@ -6115,9 +6525,9 @@
       "division": "5. divisjon",
       "band": "Åsnes Hornmusikk",
       "result_piece": "Music for a Solemnity",
-      "recording_title": "Music for a festival",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/6d6hiK8fiIAz1FyXFjtp9R",
+      "recording_title": "Music for a Solemnity",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/5zXn5g59rMzGOpKP7NqMU4",
       "apple_music": "https://music.apple.com/us/album/music-for-a-solemnity/1112522030?i=1112523076&uo=4"
     },
     {
@@ -6125,20 +6535,30 @@
       "division": "6. divisjon",
       "band": "Alversund Musikklag",
       "result_piece": "Music for a Festival",
-      "recording_title": "Music for a festival",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/6d6hiK8fiIAz1FyXFjtp9R",
-      "apple_music": "https://music.apple.com/us/album/music-for-a-solemnity/1112522030?i=1112523076&uo=4"
+      "recording_title": "Music for a Festival -",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/42UGAC5cId0sPfGWqYMOwv",
+      "apple_music": "https://music.apple.com/us/album/music-for-a-festival/1095042410?i=1095043162&uo=4"
     },
     {
       "year": 2016,
       "division": "6. divisjon",
       "band": "Byåsen Musikkorps",
       "result_piece": "Saint and the City",
-      "recording_title": "The Witch and the Saint",
-      "album": "Nm Janitsjar 2016 - 7.Divisjon",
-      "spotify": "https://open.spotify.com/track/1S77hzKabfJjFd4mBHoLPt",
-      "apple_music": null
+      "recording_title": "Saint and the City",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/3PKtSXiAqfQ7lS01dQBBen",
+      "apple_music": "https://music.apple.com/us/album/saint-and-the-city/1095042410?i=1095043155&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Byåsen Musikkorps",
+      "result_piece": "Toccata",
+      "recording_title": "Toccata",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/7h2vhUFpIMEyN4oQYFiALj",
+      "apple_music": "https://music.apple.com/us/album/toccata/1095042410?i=1095043152&uo=4"
     },
     {
       "year": 2016,
@@ -6146,29 +6566,69 @@
       "band": "Dokka Musikkorps",
       "result_piece": "Oregon",
       "recording_title": "Oregon",
-      "album": "Nm Janitsjar 2016 - 7.Divisjon",
-      "spotify": "https://open.spotify.com/track/3xdE6Tu1RlPKodGkGpPsIN",
-      "apple_music": null
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/2UlBPpworqrqBHPt94awde",
+      "apple_music": "https://music.apple.com/us/album/oregon/1095042410?i=1095043141&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Fana Musikklag",
+      "result_piece": "Vilela",
+      "recording_title": "Vilela",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/527NBYJgF8pKKHgP4Svker",
+      "apple_music": "https://music.apple.com/us/album/vilela/1095042410?i=1095043161&uo=4"
     },
     {
       "year": 2016,
       "division": "6. divisjon",
       "band": "Fet Janitsjar",
       "result_piece": "Music for a Festival",
-      "recording_title": "Music for a festival",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/6d6hiK8fiIAz1FyXFjtp9R",
-      "apple_music": "https://music.apple.com/us/album/music-for-a-solemnity/1112522030?i=1112523076&uo=4"
+      "recording_title": "Music for a Festival",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/0sfCrZHeR5NAQ0DMHOioRu",
+      "apple_music": "https://music.apple.com/us/album/music-for-a-festival/1095042410?i=1095043145&uo=4"
     },
     {
       "year": 2016,
       "division": "6. divisjon",
       "band": "Glommasvingen Janitsjar",
       "result_piece": "The Witch and the Saint",
-      "recording_title": "The Witch and the Saint",
-      "album": "Nm Janitsjar 2016 - 7.Divisjon",
-      "spotify": "https://open.spotify.com/track/1S77hzKabfJjFd4mBHoLPt",
-      "apple_music": null
+      "recording_title": "The Witch and The Saint",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/70IcLKu3HhJ5yYvx81pFz0",
+      "apple_music": "https://music.apple.com/us/album/the-witch-and-the-saint/1095042410?i=1095043156&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Hadeland Janitsjar",
+      "result_piece": "Jericho",
+      "recording_title": "Jericho",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/4bz9dLjBB6oemMgnnjWpiv",
+      "apple_music": "https://music.apple.com/us/album/jericho/1095042410?i=1095043142&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Jernbanens Musikkorps Oslo",
+      "result_piece": "Puszta (Four Gypsi Dances)",
+      "recording_title": "Puszta",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/3SPYBRYCVrY5J6ePe0v3bk",
+      "apple_music": "https://music.apple.com/us/album/puszta/1095042410?i=1095043239&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Klæbu Musikkorps",
+      "result_piece": "Fest Polonaise, Op. 12",
+      "recording_title": "Fest polonaise, op.12",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/3xvxJhgbxAhvezBjamkrht",
+      "apple_music": "https://music.apple.com/us/album/fest-polonaise-op-12/1095042410?i=1095043160&uo=4"
     },
     {
       "year": 2016,
@@ -6176,9 +6636,9 @@
       "band": "Musikklaget Ustemt",
       "result_piece": "Hispanola",
       "recording_title": "Hispaniola",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/hispaniola/1110700233?i=1110701782&uo=4"
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/6vP4siBqDqexGTrO5sutP8",
+      "apple_music": "https://music.apple.com/us/album/hispaniola/1095042410?i=1095043158&uo=4"
     },
     {
       "year": 2016,
@@ -6186,19 +6646,69 @@
       "band": "Musikkorpset TEMPO",
       "result_piece": "Fate of the Gods",
       "recording_title": "Fate of the Gods",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/4OYpJPqOyZWR58znH3JAl0",
-      "apple_music": null
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/59L8S5LTkbQDhL8heaKhdL",
+      "apple_music": "https://music.apple.com/us/album/fate-of-the-gods/1095042410?i=1095043151&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Musikkorpset TEMPO",
+      "result_piece": "Ved Rondane",
+      "recording_title": "Ved Rondane",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/7Ca4og0j9jIirRGl8hjsXf",
+      "apple_music": "https://music.apple.com/us/album/ved-rondane/1095042410?i=1095043146&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Namsos Musikkorps",
+      "result_piece": "Puszta (Four Gypsi Dances)",
+      "recording_title": "Puszta.",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/0QE8Nc6wCFj8wLLGJ4ZSI5",
+      "apple_music": "https://music.apple.com/us/album/puszta/1095042410?i=1095043135&uo=4"
     },
     {
       "year": 2016,
       "division": "6. divisjon",
       "band": "Nordre Aker Janitsjar/Grefsen Ungdomskorps",
       "result_piece": "Birth of a New Day",
-      "recording_title": "Dawn of a New Day",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/dawn-of-a-new-day/1112522030?i=1112523080&uo=4"
+      "recording_title": "Birth of a New Day",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/64G1ZmCCOKSoB8XsozHlkH",
+      "apple_music": "https://music.apple.com/us/album/birth-of-a-new-day/1095042410?i=1095043163&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Rælingen Musikklag",
+      "result_piece": "Variations for Band",
+      "recording_title": "Variations for Band",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/38UkKXg6HVFtl2DdCCxmiG",
+      "apple_music": "https://music.apple.com/us/album/variations-for-band/1095042410?i=1095043159&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Skatval Hornmusikklag",
+      "result_piece": "A Song of Hope",
+      "recording_title": "A Song of Hope",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/71cEeEhTStfCYef8RQ4Atc",
+      "apple_music": "https://music.apple.com/us/album/a-song-of-hope/1095042410?i=1095043137&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Skatval Hornmusikklag",
+      "result_piece": "The Light Eternal",
+      "recording_title": "The Light Eternal",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/4wkVzjin4eeCkphdBNhOTD",
+      "apple_music": "https://music.apple.com/us/album/the-light-eternal/1095042410?i=1095043138&uo=4"
     },
     {
       "year": 2016,
@@ -6206,9 +6716,19 @@
       "band": "Sofienberg Musikkorps",
       "result_piece": "Mother Earth (A Fanfare)",
       "recording_title": "Mother Earth",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/mother-earth/1110700233?i=1110701776&uo=4"
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/4LzAFTYPqoxftNjV0q9DzW",
+      "apple_music": "https://music.apple.com/us/album/mother-earth/1095042410?i=1095043236&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Sofienberg Musikkorps",
+      "result_piece": "Pilatus: Mountain of Dragons",
+      "recording_title": "Pilatus: Mountains of Dragons",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/7HgukZmL71qfm1NaUjjNvl",
+      "apple_music": "https://music.apple.com/us/album/pilatus-mountains-of-dragons/1095042410?i=1095043212&uo=4"
     },
     {
       "year": 2016,
@@ -6448,7 +6968,7 @@
       "recording_title": "Vesuvius",
       "album": "Nm Janitsjar 2016 - 7.Divisjon",
       "spotify": "https://open.spotify.com/track/2IZil3bxeI3PIEJHllunsi",
-      "apple_music": "https://music.apple.com/us/album/vesuvius/1112522030?i=1112523105&uo=4"
+      "apple_music": null
     },
     {
       "year": 2016,
@@ -8403,6 +8923,16 @@
     {
       "year": 2018,
       "division": "1. divisjon",
+      "band": "Alvøens Musikkforening",
+      "result_piece": "Sidus",
+      "recording_title": "Sidus",
+      "album": "Nm Janitsjar 2018 - 1 Divisjon",
+      "spotify": "https://open.spotify.com/track/3HTdezlLg8oacDvwdRM68K",
+      "apple_music": "https://music.apple.com/us/album/sidus/1369248829?i=1369248840&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "1. divisjon",
       "band": "Bjergsted Blåseensemble",
       "result_piece": "Festmusik Der Stadt Wien",
       "recording_title": "Festmusik der Stadt Wien",
@@ -8417,8 +8947,8 @@
       "result_piece": "Stabsarabesk",
       "recording_title": "Stabsarabesk",
       "album": "Nm Janitsjar 2018 - 1 Divisjon",
-      "spotify": "https://open.spotify.com/track/5n4OjpiySkGFliIhg0wWNK",
-      "apple_music": "https://music.apple.com/us/album/stabsarabesk/1369248829?i=1369248836&uo=4"
+      "spotify": "https://open.spotify.com/track/61xWAFPhh3GdqNH0B7rO26",
+      "apple_music": "https://music.apple.com/us/album/stabsarabesk/1369248829?i=1369248847&uo=4"
     },
     {
       "year": 2018,
@@ -8484,6 +9014,16 @@
       "year": 2018,
       "division": "1. divisjon",
       "band": "Nittedal og Hakadal Janitsjar",
+      "result_piece": "Divertimento",
+      "recording_title": "Divertimento",
+      "album": "Nm Janitsjar 2018 - 1 Divisjon",
+      "spotify": "https://open.spotify.com/track/0enLzjfJ0dsvuXx8NHgDXa",
+      "apple_music": "https://music.apple.com/us/album/divertimento/1369248829?i=1369248838&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "1. divisjon",
+      "band": "Nittedal og Hakadal Janitsjar",
       "result_piece": "Elegia",
       "recording_title": "Elegia",
       "album": "Nm Janitsjar 2018 - 1 Divisjon",
@@ -8494,11 +9034,31 @@
       "year": 2018,
       "division": "1. divisjon",
       "band": "Sandefjord Musikkorps",
+      "result_piece": "Incantation and Dance",
+      "recording_title": "Incantation and Dance",
+      "album": "Nm Janitsjar 2018 - 1 Divisjon",
+      "spotify": "https://open.spotify.com/track/2W96HF5U9vcY72QkZlsxyJ",
+      "apple_music": "https://music.apple.com/us/album/incantation-and-dance/1369248829?i=1369248850&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "1. divisjon",
+      "band": "Sandefjord Musikkorps",
       "result_piece": "Poéme du Feu",
       "recording_title": "Poème du feu",
       "album": "Nm Janitsjar 2018 - 1 Divisjon",
       "spotify": "https://open.spotify.com/track/5R62YQRea2Y3Tzg26Q1vYf",
       "apple_music": "https://music.apple.com/us/album/po%C3%A8me-du-feu/1369248829?i=1369248849&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "1. divisjon",
+      "band": "Sandvikens Ungdomskorps",
+      "result_piece": "Pequeña Suite para Banda",
+      "recording_title": "Penquena Suite para Band",
+      "album": "Nm Janitsjar 2018 - 1 Divisjon",
+      "spotify": "https://open.spotify.com/track/5UM1W7u989fq0Y639gBigI",
+      "apple_music": "https://music.apple.com/us/album/penquena-suite-para-band/1369248829?i=1369248835&uo=4"
     },
     {
       "year": 2018,
@@ -8553,11 +9113,21 @@
     {
       "year": 2018,
       "division": "2. divisjon",
+      "band": "Aalesunds Ungdomsmusikkorps",
+      "result_piece": "Saga Candida",
+      "recording_title": "Saga Candida",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/5WJTjiPl3XVDX3Y2cELgmH",
+      "apple_music": "https://music.apple.com/us/album/saga-candida/1369249591?i=1369249596&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "2. divisjon",
       "band": "Asker Musikkorps",
       "result_piece": "Ponte Romano",
       "recording_title": "Ponte Romano",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/1MOmskFuCtDiqqOHM9wyDW",
       "apple_music": "https://music.apple.com/us/album/ponte-romano/1369249591?i=1369249727&uo=4"
     },
     {
@@ -8566,8 +9136,8 @@
       "band": "Asker Musikkorps",
       "result_piece": "Vesuvius",
       "recording_title": "Vesuvius",
-      "album": "Nm Janitsjar 2018 - 6 Divisjon",
-      "spotify": "https://open.spotify.com/track/6GLQs69zpXI6E7O3Y2sspg",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/5PEdudUFyY2nCcrJS98bvg",
       "apple_music": "https://music.apple.com/us/album/vesuvius/1369249591?i=1369249728&uo=4"
     },
     {
@@ -8576,8 +9146,8 @@
       "band": "Bispehaugen Ungdomskorps",
       "result_piece": "Luces y Sombras",
       "recording_title": "Luces y Sombras",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/0iILrxzX0C4f3al67qKRve",
       "apple_music": "https://music.apple.com/us/album/luces-y-sombras/1369249591?i=1369249732&uo=4"
     },
     {
@@ -8586,8 +9156,8 @@
       "band": "Bjølsen Ungdomskorps",
       "result_piece": "Incantation and Dance",
       "recording_title": "Incantation and Dance",
-      "album": "Nm Janitsjar 2018 - 3 Divisjon",
-      "spotify": "https://open.spotify.com/track/7ylXaUVKcSyYHYdePWBVXj",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/5zU6nGu0LPW50TJsCONgnn",
       "apple_music": "https://music.apple.com/us/album/incantation-and-dance/1369249591?i=1369249735&uo=4"
     },
     {
@@ -8596,8 +9166,8 @@
       "band": "Bjølsen Ungdomskorps",
       "result_piece": "With Heart and Voice",
       "recording_title": "With Heart and Voice",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/6h9nEDTv9O28PbhplKYbq9",
       "apple_music": "https://music.apple.com/us/album/with-heart-and-voice/1369249591?i=1369249736&uo=4"
     },
     {
@@ -8606,8 +9176,8 @@
       "band": "Gjøvik Bykorps",
       "result_piece": "Dawn Flight",
       "recording_title": "Dawn Flight",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/77s4ND87Z6YCYsoGm0cmmm",
       "apple_music": "https://music.apple.com/us/album/dawn-flight/1369249591?i=1369249742&uo=4"
     },
     {
@@ -8616,8 +9186,8 @@
       "band": "Gjøvik Bykorps",
       "result_piece": "Gulliver's Travels",
       "recording_title": "Gulliver´s Travels",
-      "album": "Nm Janitsjar 2018 - 7 Divisjon",
-      "spotify": "https://open.spotify.com/track/1dCJyRXADiR19vGw5mmtvx",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/2zZryXtSVzipMefvj9z4RL",
       "apple_music": "https://music.apple.com/us/album/gullivers-travels/1369249591?i=1369249741&uo=4"
     },
     {
@@ -8625,9 +9195,9 @@
       "division": "2. divisjon",
       "band": "Halsen Musikkforening",
       "result_piece": "Fleodrodum",
-      "recording_title": "\"Fleodrodum\"",
-      "album": "Nm Janitsjar 2018 - 6 Divisjon",
-      "spotify": "https://open.spotify.com/track/56pokXVgpwdKH1fLhjdmEd",
+      "recording_title": "Fleodrodum",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/6rCyVN4v2qbjOoL6MACcRt",
       "apple_music": "https://music.apple.com/us/album/fleodrodum/1369249591?i=1369249598&uo=4"
     },
     {
@@ -8636,8 +9206,8 @@
       "band": "Hov Musikkorps",
       "result_piece": "La Ville Blanche et Bleue",
       "recording_title": "La Ville Blanche et Bleue",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/0u3gO1p9a7a9i6bVfSmL9J",
       "apple_music": "https://music.apple.com/us/album/la-ville-blanche-et-bleue/1369249591?i=1369249730&uo=4"
     },
     {
@@ -8646,8 +9216,8 @@
       "band": "Hov Musikkorps",
       "result_piece": "Sketches on a Tudor Psalm",
       "recording_title": "Sketches on a Tudor Psalm",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/3p58vx9Ljhp1oxV72SMWMP",
       "apple_music": "https://music.apple.com/us/album/sketches-on-a-tudor-psalm/1369249591?i=1369249731&uo=4"
     },
     {
@@ -8655,10 +9225,20 @@
       "division": "2. divisjon",
       "band": "Lungegaardens Musikkorps",
       "result_piece": "Between the Two Rivers",
-      "recording_title": "Between the two Rivers",
-      "album": "Nm Janitsjar 2018 - 3 Divisjon",
-      "spotify": "https://open.spotify.com/track/0wNWISZO3JbpsP0IwPVEXK",
+      "recording_title": "Between the two Rivers - Variations on Ein Feste Burg",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/4uMjmbmn3wVW03bFfYIdjp",
       "apple_music": "https://music.apple.com/us/album/between-the-two-rivers-variations-on-ein-feste-burg/1369249591?i=1369249729&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "2. divisjon",
+      "band": "Lørenskog Musikkorps",
+      "result_piece": "Tales and Legends",
+      "recording_title": "Tales & Legends",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/6QcZCJ2b465JyEixH4dAWV",
+      "apple_music": "https://music.apple.com/us/album/tales-legends/1369249591?i=1369249597&uo=4"
     },
     {
       "year": 2018,
@@ -8666,8 +9246,8 @@
       "band": "Os Musikkforening",
       "result_piece": "El Camino Real",
       "recording_title": "El Camino Real",
-      "album": "Nm Janitsjar 2018 - 6 Divisjon",
-      "spotify": "https://open.spotify.com/track/4z0shnBVEhyESPVx8hqtu5",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/1BfYPwfDWUQ1Zt9LhQtBWO",
       "apple_music": "https://music.apple.com/us/album/el-camino-real/1369249591?i=1369249739&uo=4"
     },
     {
@@ -8676,8 +9256,8 @@
       "band": "Os Musikkforening",
       "result_piece": "Exultate",
       "recording_title": "Exultate",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/1tbGdo0ZcJnJAs4XCw7Sul",
       "apple_music": "https://music.apple.com/us/album/exultate/1369249591?i=1369249737&uo=4"
     },
     {
@@ -8686,8 +9266,8 @@
       "band": "Os Musikkforening",
       "result_piece": "Lux Aurumque",
       "recording_title": "Lux Arumque",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/3dzDF10pn2Q1DeNdTneFA4",
       "apple_music": "https://music.apple.com/us/album/lux-arumque/1369249591?i=1369249738&uo=4"
     },
     {
@@ -8695,9 +9275,9 @@
       "division": "2. divisjon",
       "band": "Prosjekt MMXIX",
       "result_piece": "The Planets, 1. sats Mars The Bringer of the War",
-      "recording_title": "The Planets - Jupiter, The bringer of Jollity",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "recording_title": "The Planets - Jupiter, the bringer of Jollity",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/1B5XvG8A6YzhCshkUW7Hnc",
       "apple_music": "https://music.apple.com/us/album/the-planets-jupiter-the-bringer-of-jollity/1369249591?i=1369249734&uo=4"
     },
     {
@@ -8705,9 +9285,9 @@
       "division": "2. divisjon",
       "band": "Prosjekt MMXIX",
       "result_piece": "The Planets, 4. sats Jupiter The Bringer of Jollity",
-      "recording_title": "The Planets - Jupiter, The bringer of Jollity",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "recording_title": "The Planets - Jupiter, the bringer of Jollity",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/1B5XvG8A6YzhCshkUW7Hnc",
       "apple_music": "https://music.apple.com/us/album/the-planets-jupiter-the-bringer-of-jollity/1369249591?i=1369249734&uo=4"
     },
     {
@@ -8715,9 +9295,9 @@
       "division": "2. divisjon",
       "band": "Sande Musikkorps",
       "result_piece": "Armenian Dances, Part 1",
-      "recording_title": "Armenian Dances, part 1",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "recording_title": "Armenian Dances, Pt. 1",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/3YDIbLDbsJxp2UGDmkVxKV",
       "apple_music": "https://music.apple.com/us/album/armenian-dances-part-1/1369249591?i=1369249726&uo=4"
     },
     {
@@ -8726,8 +9306,8 @@
       "band": "Sande Musikkorps",
       "result_piece": "Overture & March \"1776\"",
       "recording_title": "Overture & March \"1776\"",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/7A7ti8PT1Nw6wmH2vxdMaY",
       "apple_music": "https://music.apple.com/us/album/overture-march-1776/1369249591?i=1369249721&uo=4"
     },
     {
@@ -8736,8 +9316,8 @@
       "band": "Sinsen Konsertorkester",
       "result_piece": "Danceries",
       "recording_title": "Danceries",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/6ADP6SzEdJ9hllywjr5jx2",
       "apple_music": "https://music.apple.com/us/album/danceries/1369249591?i=1369249743&uo=4"
     },
     {
@@ -8746,8 +9326,8 @@
       "band": "Sinsen Konsertorkester",
       "result_piece": "Overture on Russian and Kirgiz folk themes",
       "recording_title": "Overture on Russian and Kirghiz folk themes",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/6GKDwvmPmkjkseZwLH7ofp",
       "apple_music": "https://music.apple.com/us/album/overture-on-russian-and-kirghiz-folk-themes/1369249591?i=1369249747&uo=4"
     },
     {
@@ -8756,8 +9336,8 @@
       "band": "Stabekk Janitsjarorkester",
       "result_piece": "Homenaje a Joaquìn Sorolla Cuados Sinfònicos",
       "recording_title": "Homenaje a Joaquin Sorolla",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/2DZyP1HxCnC9ZtyMKKLR2s",
       "apple_music": "https://music.apple.com/us/album/homenaje-a-joaquin-sorolla/1369249591?i=1369249750&uo=4"
     },
     {
@@ -8766,9 +9346,19 @@
       "band": "Sykkylven Janitsjarorkester",
       "result_piece": "Festival Overture, Op. 39",
       "recording_title": "Festival Overture",
-      "album": "Nm Janitsjar 2018 - 3 Divisjon",
-      "spotify": "https://open.spotify.com/track/0Yx50gQDVbUqlLotmDMkIE",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/5loTIqmQEnmtQQEwk5inSd",
       "apple_music": "https://music.apple.com/us/album/festival-overture/1369249591?i=1369249599&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "2. divisjon",
+      "band": "Sykkylven Janitsjarorkester",
+      "result_piece": "Kokopelli’s Dance",
+      "recording_title": "Kokopelli´s Dance",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/0EhLYaZeuBu3dtYaAsUAZm",
+      "apple_music": "https://music.apple.com/us/album/kokopellis-dance/1369249591?i=1369249600&uo=4"
     },
     {
       "year": 2018,
@@ -8776,8 +9366,8 @@
       "band": "Vestsidens Musikkorps",
       "result_piece": "Dances from Crete",
       "recording_title": "Dances from Crete",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/2Y8UJngYVtphWIcMd2hPhb",
       "apple_music": "https://music.apple.com/us/album/dances-from-crete/1369249591?i=1369249740&uo=4"
     },
     {
@@ -9156,8 +9746,8 @@
       "band": "Alvdal-Tynset Janitsjarkorps",
       "result_piece": "Prelude, Siciliano and Rondo",
       "recording_title": "Prelude, Siciliano and Rondo",
-      "album": "Nm Janitsjar 2018 - 7 Divisjon",
-      "spotify": "https://open.spotify.com/track/6FSHi0wHPXkzdqmgPd9CfB",
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/5D4i3fhtgHcmmGRu3Ipj23",
       "apple_music": "https://music.apple.com/us/album/prelude-siciliano-and-rondo/1369259321?i=1369259501&uo=4"
     },
     {
@@ -9165,9 +9755,9 @@
       "division": "5. divisjon",
       "band": "Alvdal-Tynset Janitsjarkorps",
       "result_piece": "With Each Sunset (Comes the Promise of a New Day)",
-      "recording_title": "With Each Sunset",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "recording_title": "With each sunset",
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/6h5WGyhcP4JMfVWB7Q0n9Y",
       "apple_music": "https://music.apple.com/us/album/with-each-sunset/1369259321?i=1369259502&uo=4"
     },
     {
@@ -9176,9 +9766,29 @@
       "band": "Byåsen Musikkorps",
       "result_piece": "El Camino Real",
       "recording_title": "El Camino Real",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/1u9xCQ8r9nzc2jFkHOvpJv",
       "apple_music": "https://music.apple.com/us/album/el-camino-real/1369259321?i=1369259406&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "5. divisjon",
+      "band": "Bømlo Janitsjar",
+      "result_piece": "Lake of the Moon",
+      "recording_title": "Lake of the Moon",
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/5Wwvdkr3KVTpW54Fne9Ypy",
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon/1369259321?i=1369259405&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "5. divisjon",
+      "band": "Drøbak Musikkorps",
+      "result_piece": "Armenian Dances, Part 1",
+      "recording_title": "Armenske Danser, Del 1",
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/6ny4JjyFnqwlBdmm87NVaL",
+      "apple_music": "https://music.apple.com/us/album/armenian-dances-part-1/1369249591?i=1369249726&uo=4"
     },
     {
       "year": 2018,
@@ -9186,8 +9796,8 @@
       "band": "Fana Musikklag",
       "result_piece": "Dreamland",
       "recording_title": "Dreamland",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/6ZvCFXkcTmUbameI4tyHv9",
       "apple_music": "https://music.apple.com/us/album/dreamland/1369259321?i=1369259392&uo=4"
     },
     {
@@ -9196,8 +9806,8 @@
       "band": "Fana Musikklag",
       "result_piece": "Exultate",
       "recording_title": "Exultate",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/3D6x8dCELbwOo84EXdZeiF",
       "apple_music": "https://music.apple.com/us/album/exultate/1369259321?i=1369259395&uo=4"
     },
     {
@@ -9206,8 +9816,8 @@
       "band": "Haugesund Janitsjarorkester",
       "result_piece": "In Flight",
       "recording_title": "In Flight",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/3nyVQmbBhaP5oYj2IwVbgV",
       "apple_music": "https://music.apple.com/us/album/in-flight/1369259321?i=1369259401&uo=4"
     },
     {
@@ -9216,9 +9826,19 @@
       "band": "Haugesund Janitsjarorkester",
       "result_piece": "The Hounds of Spring",
       "recording_title": "The Hounds of Spring",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/6JGItTFx8YayAQ7XsdWYZ9",
       "apple_music": "https://music.apple.com/us/album/the-hounds-of-spring/1369259321?i=1369259402&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "5. divisjon",
+      "band": "Jernbanens Musikkorps Oslo",
+      "result_piece": "Lake of the Moon",
+      "recording_title": "Lake of the Moon",
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/0yseDndRJlQ2SMMvgIV8OK",
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon/1369259321?i=1369259396&uo=4"
     },
     {
       "year": 2018,
@@ -9226,8 +9846,8 @@
       "band": "Musikklaget Kornetten",
       "result_piece": "The Witch and the Saint",
       "recording_title": "The Witch and the Saint",
-      "album": "Nm Janitsjar 2018 - 7 Divisjon",
-      "spotify": "https://open.spotify.com/track/6uc02c7dcgAkGJop6C9XX1",
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/18JJ25eEvGZiW0CmQCozAz",
       "apple_music": "https://music.apple.com/us/album/the-witch-and-the-saint/1369259321?i=1369259398&uo=4"
     },
     {
@@ -9236,8 +9856,8 @@
       "band": "Nannestad Janitsjarkorps",
       "result_piece": "subTERRA",
       "recording_title": "SubTERRA",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/36WpcGhzbasO1JCEfXVgry",
       "apple_music": "https://music.apple.com/us/album/subterra/1369259321?i=1369259403&uo=4"
     },
     {
@@ -9246,8 +9866,8 @@
       "band": "Oslo Janitsjarkorps",
       "result_piece": "Ascension",
       "recording_title": "The Ascension",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/2P21ii7zJPlFdwp7oWyNha",
       "apple_music": "https://music.apple.com/us/album/the-ascension/1369259321?i=1369259410&uo=4"
     },
     {
@@ -9256,8 +9876,8 @@
       "band": "Oslo Janitsjarkorps",
       "result_piece": "The Divine Comedy, 2. sats Purgatorio",
       "recording_title": "Purgatorio",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/2qdXFPIbbqnTUlLuDbQRuo",
       "apple_music": "https://music.apple.com/us/album/purgatorio/1369259321?i=1369259409&uo=4"
     },
     {
@@ -9266,8 +9886,8 @@
       "band": "Rælingen Musikklag",
       "result_piece": "The Magnetic Mountain",
       "recording_title": "The Magnetic Mountain",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/19dCmVNSJHRCGOqn4UZoId",
       "apple_music": "https://music.apple.com/us/album/the-magnetic-mountain/1369259321?i=1369259400&uo=4"
     },
     {
@@ -9276,8 +9896,8 @@
       "band": "Strinda Ungdomskorps",
       "result_piece": "Jericho",
       "recording_title": "Jericho",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/6uLgxobWpGL8IrPKHP5A9T",
       "apple_music": "https://music.apple.com/us/album/jericho/1369259321?i=1369259397&uo=4"
     },
     {
@@ -9286,9 +9906,9 @@
       "band": "Tolga-Os Janitsjar",
       "result_piece": "subTERRA",
       "recording_title": "SubTERRA",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/subterra/1369259321?i=1369259403&uo=4"
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/0L0KxOjugLG1M89NaXayax",
+      "apple_music": "https://music.apple.com/us/album/subterra/1369259321?i=1369259404&uo=4"
     },
     {
       "year": 2018,
@@ -9296,8 +9916,8 @@
       "band": "Tvedestrand Musikkorps",
       "result_piece": "Yiddish Dances, 1., 2., 4. og 5. sats",
       "recording_title": "Yiddish Dances, sats 1,2,4 og 5",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/5HSTYFDTkgABAl4sV6vGL4",
       "apple_music": "https://music.apple.com/us/album/yiddish-dances-sats-1-2-4-og-5/1369259321?i=1369259407&uo=4"
     },
     {
@@ -9306,8 +9926,8 @@
       "band": "Vålerenga Janitsjarkorps",
       "result_piece": "Saga Maligna",
       "recording_title": "Saga Maligna",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/2rk1JqSr36sv5j6bkCvqPy",
       "apple_music": "https://music.apple.com/us/album/saga-maligna/1369259321?i=1369259399&uo=4"
     },
     {
@@ -9316,8 +9936,8 @@
       "band": "Åsnes Hornmusikk",
       "result_piece": "The Curse of the Mermaid",
       "recording_title": "The Curse of the Mermaid",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/5b2emYEXh8lnR0bXY2kuBE",
       "apple_music": "https://music.apple.com/us/album/the-curse-of-the-mermaid/1369259321?i=1369259408&uo=4"
     },
     {
@@ -9337,8 +9957,28 @@
       "result_piece": "Gulliver's Travels",
       "recording_title": "Gulliver´s Travels",
       "album": "Nm Janitsjar 2018 - 6 Divisjon",
-      "spotify": "https://open.spotify.com/track/0WgTiYhNu9htTRSIirDicE",
-      "apple_music": "https://music.apple.com/us/album/gullivers-travels/1369268596?i=1369268717&uo=4"
+      "spotify": "https://open.spotify.com/track/3SboDdBfSAiSmSiw4NRkWz",
+      "apple_music": "https://music.apple.com/us/album/gullivers-travels/1369268596?i=1369268732&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "6. divisjon",
+      "band": "Hadeland Janitsjar",
+      "result_piece": "Overture to a new Age",
+      "recording_title": "Overture to a New Age",
+      "album": "Nm Janitsjar 2018 - 6 Divisjon",
+      "spotify": "https://open.spotify.com/track/2kAxsFsqI2y6e1IhcL7oKu",
+      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age/1369268596?i=1369268721&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "6. divisjon",
+      "band": "Hamar Musikkorps",
+      "result_piece": "Overture to a new Age",
+      "recording_title": "Overture to a New Age",
+      "album": "Nm Janitsjar 2018 - 6 Divisjon",
+      "spotify": "https://open.spotify.com/track/7LwodwD90CLISSvy3CZ0DR",
+      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age/1369268596?i=1369268739&uo=4"
     },
     {
       "year": 2018,
@@ -9369,6 +10009,16 @@
       "album": "Nm Janitsjar 2018 - 6 Divisjon",
       "spotify": "https://open.spotify.com/track/0WgTiYhNu9htTRSIirDicE",
       "apple_music": "https://music.apple.com/us/album/gullivers-travels/1369268596?i=1369268717&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "6. divisjon",
+      "band": "Hønefoss Ungdomskorps",
+      "result_piece": "Mont Blanc",
+      "recording_title": "Mont Blanc - La Voie Royale",
+      "album": "Nm Janitsjar 2018 - 6 Divisjon",
+      "spotify": "https://open.spotify.com/track/6rvdtupkalKPX7xzkzl9t4",
+      "apple_music": "https://music.apple.com/us/album/mont-blanc-la-voie-royale/1369268596?i=1369268741&uo=4"
     },
     {
       "year": 2018,
@@ -9449,6 +10099,16 @@
       "album": "Nm Janitsjar 2018 - 6 Divisjon",
       "spotify": "https://open.spotify.com/track/6GLQs69zpXI6E7O3Y2sspg",
       "apple_music": "https://music.apple.com/us/album/vesuvius/1369268596?i=1369268728&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "6. divisjon",
+      "band": "Musikkorpset TEMPO",
+      "result_piece": "The Witch and the Saint",
+      "recording_title": "The Witch and the Saint",
+      "album": "Nm Janitsjar 2018 - 6 Divisjon",
+      "spotify": "https://open.spotify.com/track/7mKwXgHYFobhLtb9DDvkFS",
+      "apple_music": "https://music.apple.com/us/album/the-witch-and-the-saint/1369268596?i=1369268714&uo=4"
     },
     {
       "year": 2018,
@@ -9559,6 +10219,16 @@
       "album": "Nm Janitsjar 2018 - 7 Divisjon",
       "spotify": "https://open.spotify.com/track/3zayZV4aDWFuXm057nchh9",
       "apple_music": "https://music.apple.com/us/album/concerto-damore/1369288211?i=1369288218&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "7. divisjon",
+      "band": "Flatåsen Musikkorps",
+      "result_piece": "Edenstrand",
+      "recording_title": "Edenstrand",
+      "album": "Nm Janitsjar 2018 - 7 Divisjon",
+      "spotify": "https://open.spotify.com/track/4bZNGeSKpjRehRtxnEqhOQ",
+      "apple_music": "https://music.apple.com/us/album/edenstrand/1369288211?i=1369288219&uo=4"
     },
     {
       "year": 2018,
@@ -9734,11 +10404,21 @@
       "year": 2018,
       "division": "7. divisjon",
       "band": "Østerdal Prosjektkorps",
+      "result_piece": "Concert Prelude",
+      "recording_title": "Concert Prelude",
+      "album": "Nm Janitsjar 2018 - 7 Divisjon",
+      "spotify": "https://open.spotify.com/track/72UkHgT0w3t4EPgioFmCyY",
+      "apple_music": "https://music.apple.com/us/album/concert-prelude/1369288211?i=1369288305&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "7. divisjon",
+      "band": "Østerdal Prosjektkorps",
       "result_piece": "Gulliver's Travels",
       "recording_title": "Gulliver´s Travels",
       "album": "Nm Janitsjar 2018 - 7 Divisjon",
-      "spotify": "https://open.spotify.com/track/1dCJyRXADiR19vGw5mmtvx",
-      "apple_music": "https://music.apple.com/us/album/gullivers-travels/1369288211?i=1369288240&uo=4"
+      "spotify": "https://open.spotify.com/track/0GHCsXbIgwOi0gSwTINo0S",
+      "apple_music": "https://music.apple.com/us/album/gullivers-travels/1369288211?i=1369288306&uo=4"
     },
     {
       "year": 2018,
@@ -9759,6 +10439,16 @@
       "album": "Nm Janitsjar 2018 - Elitedivisjon",
       "spotify": "https://open.spotify.com/track/5rfakSZvEGouCn88WmueMU",
       "apple_music": "https://music.apple.com/us/album/short-ride-in-a-fast-machine/1369246521?i=1369246903&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "Stabsarabesk",
+      "recording_title": "Stabsarabesk",
+      "album": "Nm Janitsjar 2018 - Elitedivisjon",
+      "spotify": "https://open.spotify.com/track/6vGkULM10yzmlEwhbmhyCo",
+      "apple_music": "https://music.apple.com/us/album/stabsarabesk/1369246521?i=1369246906&uo=4"
     },
     {
       "year": 2018,
@@ -9793,6 +10483,16 @@
     {
       "year": 2018,
       "division": "Elite",
+      "band": "Lillestrøm Musikkorps",
+      "result_piece": "Symphony no. 4",
+      "recording_title": "Symphony No. 4",
+      "album": "Nm Janitsjar 2018 - Elitedivisjon",
+      "spotify": "https://open.spotify.com/track/0OSmaJdxkqe2Fmd5laM2O2",
+      "apple_music": "https://music.apple.com/us/album/symphony-no-4/1369246521?i=1369246902&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "Elite",
       "band": "Mo Hornmusikk",
       "result_piece": "Danza de los Duendes",
       "recording_title": "Danza de los Duendes",
@@ -9814,6 +10514,16 @@
       "year": 2018,
       "division": "Elite",
       "band": "Musikkforeningen Nidarholm",
+      "result_piece": "Bachseits",
+      "recording_title": "Bachseits",
+      "album": "Nm Janitsjar 2018 - Elitedivisjon",
+      "spotify": "https://open.spotify.com/track/4kyDXxiqNlTAO3ZSfko6Lu",
+      "apple_music": "https://music.apple.com/us/album/bachseits/1369246521?i=1369246901&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "Elite",
+      "band": "Musikkforeningen Nidarholm",
       "result_piece": "Symphony no. 1 for Wind Band: Solitude Standing",
       "recording_title": "Symphony no. 1 for wind band - Solitude Standing",
       "album": "Nm Janitsjar 2018 - Elitedivisjon",
@@ -9829,6 +10539,26 @@
       "album": "Nm Janitsjar 2018 - Elitedivisjon",
       "spotify": "https://open.spotify.com/track/4OnmODJ4wPPWJF0Axh9k0T",
       "apple_music": "https://music.apple.com/us/album/fantasy-variations/1369246521?i=1369246899&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "Elite",
+      "band": "Opus 82",
+      "result_piece": "Traveler",
+      "recording_title": "Traveler",
+      "album": "Nm Janitsjar 2018 - Elitedivisjon",
+      "spotify": "https://open.spotify.com/track/5A21dITYlcpx2Zjn5x3vvc",
+      "apple_music": "https://music.apple.com/us/album/traveler/1369246521?i=1369246898&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "Elite",
+      "band": "Sarpsborg Janitsjarkorps",
+      "result_piece": "Changes",
+      "recording_title": "Changes for Symphonic Wind Band",
+      "album": "Nm Janitsjar 2018 - Elitedivisjon",
+      "spotify": "https://open.spotify.com/track/3LijeEXdtpxisOQnFIdnKk",
+      "apple_music": "https://music.apple.com/us/album/changes-for-symphonic-wind-band/1369246521?i=1369246908&uo=4"
     },
     {
       "year": 2018,
@@ -10526,8 +11256,8 @@
       "band": "Arendal Byorkester",
       "result_piece": "Noah’s Ark",
       "recording_title": "Noah´s Ark",
-      "album": "NM Janitsjar 2019 - 7 divisjon",
-      "spotify": "https://open.spotify.com/track/76GvvjlVoYFImnKAn53yqI",
+      "album": "NM Janitsjar 2019 - 4 divisjon",
+      "spotify": "https://open.spotify.com/track/140oUbH3Q6ZK5TZItqsri2",
       "apple_music": "https://music.apple.com/us/album/noahs-ark/1460693460?i=1460693471&uo=4"
     },
     {
@@ -10537,7 +11267,7 @@
       "result_piece": "Goddess of Fire",
       "recording_title": "Goddess of Fire",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/0QW545OmrTbiot8db9Wzki",
       "apple_music": "https://music.apple.com/us/album/goddess-of-fire/1460693460?i=1460694004&uo=4"
     },
     {
@@ -10547,17 +11277,17 @@
       "result_piece": "Rush",
       "recording_title": "Rush",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/rush/1460693460?i=1460693730&uo=4"
+      "spotify": "https://open.spotify.com/track/5D5d8m7VV7ipS8MdFThTZ5",
+      "apple_music": "https://music.apple.com/us/album/rush/1460693460?i=1460694009&uo=4"
     },
     {
       "year": 2019,
       "division": "4. divisjon",
       "band": "Bodø Harmonimusikk",
       "result_piece": "Angels in the Architecture",
-      "recording_title": "Angels in Architecture",
-      "album": "NM Janitsjar 2019 - 6 divisjon",
-      "spotify": "https://open.spotify.com/track/6QkShd68GtKno2V0jcqLf0",
+      "recording_title": "Angels in the Architecture",
+      "album": "NM Janitsjar 2019 - 4 divisjon",
+      "spotify": "https://open.spotify.com/track/5Oj4d8fZE6KO3sDxOeYbgY",
       "apple_music": "https://music.apple.com/us/album/angels-in-the-architecture/1460693460?i=1460693569&uo=4"
     },
     {
@@ -10567,7 +11297,7 @@
       "result_piece": "Eine Kleine Yiddishe Ragmusik",
       "recording_title": "Eine Kleine Yiddishe Ragmusik",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/5dUQMWzH7Kxn1UkSeJX7Y8",
       "apple_music": "https://music.apple.com/us/album/eine-kleine-yiddishe-ragmusik/1460693460?i=1460693914&uo=4"
     },
     {
@@ -10577,7 +11307,7 @@
       "result_piece": "The Hounds of Spring",
       "recording_title": "The Hounds of Spring",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6IqSGB0676A3QRoEHQCfog",
       "apple_music": "https://music.apple.com/us/album/the-hounds-of-spring/1460693460?i=1460693925&uo=4"
     },
     {
@@ -10587,7 +11317,7 @@
       "result_piece": "Lake of the Moon",
       "recording_title": "Lake of the Moon",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4AIIM66iadETV8RhmStetJ",
       "apple_music": "https://music.apple.com/us/album/lake-of-the-moon/1460693460?i=1460694002&uo=4"
     },
     {
@@ -10597,7 +11327,7 @@
       "result_piece": "Between the Two Rivers",
       "recording_title": "Between the Two Rivers",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/12lcKq6PBMm5QID1oLI9Ji",
       "apple_music": "https://music.apple.com/us/album/between-the-two-rivers/1460693460?i=1460694000&uo=4"
     },
     {
@@ -10606,8 +11336,8 @@
       "band": "Haugesund Janitsjarorkester",
       "result_piece": "El Camino Real",
       "recording_title": "El Camino Real",
-      "album": "NM Janitsjar 2019 - 7 divisjon",
-      "spotify": "https://open.spotify.com/track/487VeYM3aLq8QCeduUN89I",
+      "album": "NM Janitsjar 2019 - 4 divisjon",
+      "spotify": "https://open.spotify.com/track/0CC2MgrmNZ2D6NIvKMtmxn",
       "apple_music": "https://music.apple.com/us/album/el-camino-real/1460693460?i=1460693742&uo=4"
     },
     {
@@ -10617,7 +11347,7 @@
       "result_piece": "Rush",
       "recording_title": "Rush",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4dfpYidDrFtMrXibL3eRsj",
       "apple_music": "https://music.apple.com/us/album/rush/1460693460?i=1460693730&uo=4"
     },
     {
@@ -10625,9 +11355,9 @@
       "division": "4. divisjon",
       "band": "Musikkforeningen Viken",
       "result_piece": "Gulliver's Travels",
-      "recording_title": "Gulliver's Travels",
+      "recording_title": "Gulliver´s Travels",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/7csh62xPN8d6MOlmJvdgDv",
       "apple_music": "https://music.apple.com/us/album/gullivers-travels/1460693460?i=1460693474&uo=4"
     },
     {
@@ -10637,7 +11367,7 @@
       "result_piece": "Sea Songs",
       "recording_title": "Sea songs",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/7wsPyEXdOKsvNn4gjKTAba",
       "apple_music": "https://music.apple.com/us/album/sea-songs/1460693460?i=1460693478&uo=4"
     },
     {
@@ -10647,7 +11377,7 @@
       "result_piece": "The Land of the Long White Cloud",
       "recording_title": "The Land of the Long White Cloud",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/1aXdSVk9Mav0B1Z2PJnt18",
       "apple_music": "https://music.apple.com/us/album/the-land-of-the-long-white-cloud/1460693460?i=1460693744&uo=4"
     },
     {
@@ -10656,9 +11386,9 @@
       "band": "Oppegård Janitsjar",
       "result_piece": "Hispanola",
       "recording_title": "Hipaniola",
-      "album": "NM Janitsjar 2019 - 6 divisjon",
-      "spotify": "https://open.spotify.com/track/7jZRfKQLyXt4ATjOhti1lR",
-      "apple_music": "https://music.apple.com/us/album/hipaniola/1460190452?i=1460190704&uo=4"
+      "album": "NM Janitsjar 2019 - 4 divisjon",
+      "spotify": "https://open.spotify.com/track/1vzK6Fh5rt1fBF7L9EMrHI",
+      "apple_music": "https://music.apple.com/us/album/hipaniola/1460693460?i=1460693554&uo=4"
     },
     {
       "year": 2019,
@@ -10667,7 +11397,7 @@
       "result_piece": "A Moorside suite, 3. sats March",
       "recording_title": "A Moorside Suite - 3 sats, March",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/0YBMZFM2LpT48sNCF7U4dm",
       "apple_music": "https://music.apple.com/us/album/a-moorside-suite-3-sats-march/1460693460?i=1460693548&uo=4"
     },
     {
@@ -10677,7 +11407,7 @@
       "result_piece": "Sacred Harp",
       "recording_title": "Sacred Harp",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/42YmR6cPqSKxKHDHhgSuvZ",
       "apple_music": "https://music.apple.com/us/album/sacred-harp/1460693460?i=1460693553&uo=4"
     },
     {
@@ -10686,9 +11416,9 @@
       "band": "Ringsaker Janitjsar",
       "result_piece": "Machu Picchu - City in the sky - the mystery of the hidden sun Temple",
       "recording_title": "Machu Picchu",
-      "album": "NM Janitsjar 2019 - 6 divisjon",
-      "spotify": "https://open.spotify.com/track/5n3WllGdGHV4lEJa2oduGI",
-      "apple_music": "https://music.apple.com/us/album/machu-picchu/1460190452?i=1460190474&uo=4"
+      "album": "NM Janitsjar 2019 - 4 divisjon",
+      "spotify": "https://open.spotify.com/track/3ZcXRYRfTt3UZX3ZehQMSS",
+      "apple_music": "https://music.apple.com/us/album/machu-picchu/1460693460?i=1460693566&uo=4"
     },
     {
       "year": 2019,
@@ -10697,7 +11427,7 @@
       "result_piece": "Of Ancient Dances",
       "recording_title": "Of Ancient Dances",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4AwPkINdwpFHf6cMLfTb86",
       "apple_music": "https://music.apple.com/us/album/of-ancient-dances/1460693460?i=1460693997&uo=4"
     },
     {
@@ -10706,9 +11436,9 @@
       "band": "Sofienberg Musikkorps",
       "result_piece": "Machu Picchu - City in the sky - the mystery of the hidden sun Temple",
       "recording_title": "Machu Picchu",
-      "album": "NM Janitsjar 2019 - 6 divisjon",
-      "spotify": "https://open.spotify.com/track/5n3WllGdGHV4lEJa2oduGI",
-      "apple_music": "https://music.apple.com/us/album/machu-picchu/1460190452?i=1460190474&uo=4"
+      "album": "NM Janitsjar 2019 - 4 divisjon",
+      "spotify": "https://open.spotify.com/track/1K3gAE8NXf0mHwm5Cxk4Xw",
+      "apple_music": "https://music.apple.com/us/album/machu-picchu/1460693460?i=1460693558&uo=4"
     },
     {
       "year": 2019,
@@ -10717,7 +11447,7 @@
       "result_piece": "subTERRA",
       "recording_title": "subTERRA",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/57mPK8pvb2zkvuhQJYw8AJ",
       "apple_music": "https://music.apple.com/us/album/subterra/1460693460?i=1460693562&uo=4"
     },
     {
@@ -10727,7 +11457,7 @@
       "result_piece": "Time for Outrage!",
       "recording_title": "Time for Outrage !",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/5yEI11Tw84vvXUhHtKx8HK",
       "apple_music": "https://music.apple.com/us/album/time-for-outrage/1460693460?i=1460693931&uo=4"
     },
     {
@@ -10735,30 +11465,110 @@
       "division": "5. divisjon",
       "band": "Alvdal-Tynset Janitsjarkorps",
       "result_piece": "Goddess of Fire",
-      "recording_title": "Goddess of Fire",
-      "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/goddess-of-fire/1460693460?i=1460694004&uo=4"
+      "recording_title": "Goddess of fire",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/3oW8p6bRs2ypFIdCO4YEMf",
+      "apple_music": "https://music.apple.com/us/album/goddess-of-fire/1460701955?i=1460702075&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Alvdal-Tynset Janitsjarkorps",
+      "result_piece": "Take Off",
+      "recording_title": "Take Off",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/4mGdpEtnaErSZ5zayb5OpY",
+      "apple_music": "https://music.apple.com/us/album/take-off/1460701955?i=1460701971&uo=4"
     },
     {
       "year": 2019,
       "division": "5. divisjon",
       "band": "Bømlo Janitsjar",
       "result_piece": "Saga Maligna",
-      "recording_title": "Saga Candida",
-      "album": "NM Janitsjar 2019 - 2 divisjon",
-      "spotify": "https://open.spotify.com/track/3VpsF6P5L5jEDisb4owXCI",
-      "apple_music": "https://music.apple.com/us/album/saga-candida/1460683954?i=1460685103&uo=4"
+      "recording_title": "Saga Maligna",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/4ExCmsMej78OIfBxTlb6Z5",
+      "apple_music": "https://music.apple.com/us/album/saga-maligna/1460701955?i=1460702654&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Fana Musikklag",
+      "result_piece": "Deliverance",
+      "recording_title": "Deliverance",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/1B5bPD8nmY3XobDxNDHDn2",
+      "apple_music": "https://music.apple.com/us/album/deliverance/1460701955?i=1460702575&uo=4"
     },
     {
       "year": 2019,
       "division": "5. divisjon",
       "band": "Hamar Musikkorps",
       "result_piece": "Mont Blanc",
-      "recording_title": "Mont-Blanc La voie Royale",
-      "album": "NM Janitsjar 2019 - 6 divisjon",
-      "spotify": "https://open.spotify.com/track/3Hkr1sBWG3WJdzKLDtMJGO",
-      "apple_music": "https://music.apple.com/us/album/mont-blanc-la-voie-royale/1460190452?i=1460190778&uo=4"
+      "recording_title": "Mont-Blanc",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/69nTp1psIIyfg3Ah9I1Naj",
+      "apple_music": "https://music.apple.com/us/album/mont-blanc/1460701955?i=1460702642&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Heimdal Musikkorps",
+      "result_piece": "Slava!",
+      "recording_title": "Slava!",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/30APweHMzAhcT6YFvz1Guk",
+      "apple_music": "https://music.apple.com/us/album/slava/1460701955?i=1460703149&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Heimdal Musikkorps",
+      "result_piece": "Songs of Sailor and Sea",
+      "recording_title": "Song of Sailor and Sea",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/4JWAW1Fj3o3YluC0H4lWfD",
+      "apple_music": "https://music.apple.com/us/album/song-of-sailor-and-sea/1460701955?i=1460703167&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Jernbanens Musikkorps Oslo",
+      "result_piece": "The Junction Point",
+      "recording_title": "The Junction Point",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/6V1wsbSpckjPZhL6qYqG7V",
+      "apple_music": "https://music.apple.com/us/album/the-junction-point/1460701955?i=1460702965&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Melhus Janitsjarkorps",
+      "result_piece": "Flying the Breeze",
+      "recording_title": "Flying the Breeze",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/738IMEsfhwpBXuQyGStbpg",
+      "apple_music": "https://music.apple.com/us/album/flying-the-breeze/1460701955?i=1460702869&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Melhus Janitsjarkorps",
+      "result_piece": "Tales and Myths of Gothia",
+      "recording_title": "Tales and Myths of Gothia",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/6QfhcuQtr7rSi35aIbsB7d",
+      "apple_music": "https://music.apple.com/us/album/tales-and-myths-of-gothia/1460701955?i=1460702853&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Mjøsen Janitsjar",
+      "result_piece": "Chorale and Variations",
+      "recording_title": "Chorale and Variations",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/7IRaLdpF5VZ454ZT2Tmo3n",
+      "apple_music": "https://music.apple.com/us/album/chorale-and-variations/1460701955?i=1460702282&uo=4"
     },
     {
       "year": 2019,
@@ -10766,9 +11576,9 @@
       "band": "Musikklaget Kornetten",
       "result_piece": "Noah’s Ark",
       "recording_title": "Noah´s Ark",
-      "album": "NM Janitsjar 2019 - 7 divisjon",
-      "spotify": "https://open.spotify.com/track/76GvvjlVoYFImnKAn53yqI",
-      "apple_music": "https://music.apple.com/us/album/noahs-ark/1460693460?i=1460693471&uo=4"
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/0LhIMbVLAQVZHGeDuXPOph",
+      "apple_music": "https://music.apple.com/us/album/noahs-ark/1460701955?i=1460702085&uo=4"
     },
     {
       "year": 2019,
@@ -10776,9 +11586,29 @@
       "band": "Musikklaget Ustemt",
       "result_piece": "El Camino Real",
       "recording_title": "El Camino Real",
-      "album": "NM Janitsjar 2019 - 7 divisjon",
-      "spotify": "https://open.spotify.com/track/487VeYM3aLq8QCeduUN89I",
-      "apple_music": "https://music.apple.com/us/album/el-camino-real/1460693460?i=1460693742&uo=4"
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/69EyE0tsvsxGRsrWGVefTX",
+      "apple_music": "https://music.apple.com/us/album/el-camino-real/1460701955?i=1460702950&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Musikklaget Ustemt",
+      "result_piece": "Landscapes",
+      "recording_title": "Landscapes",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/7affNcsVVTzGhmmgdmHzV1",
+      "apple_music": "https://music.apple.com/us/album/landscapes/1460701955?i=1460702873&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Odda Musikklag",
+      "result_piece": "Lebuinus ex Daventria",
+      "recording_title": "Lebuins ex Daventria",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/7MNdpBvZyneM106joWWgVa",
+      "apple_music": "https://music.apple.com/us/album/lebuins-ex-daventria/1460701955?i=1460702358&uo=4"
     },
     {
       "year": 2019,
@@ -10786,9 +11616,29 @@
       "band": "Rælingen Musikklag",
       "result_piece": "Pilatus: Mountain of Dragons",
       "recording_title": "Pilatus: Mountain of Dragons",
-      "album": "NM Janitsjar 2019 - 6 divisjon",
-      "spotify": "https://open.spotify.com/track/5lkZZNAFDOyMgxFPPCWY7z",
-      "apple_music": "https://music.apple.com/us/album/pilatus-mountain-of-dragons/1460190452?i=1460190854&uo=4"
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/4xYGj7rVZC4YzCn1zfkVz1",
+      "apple_music": "https://music.apple.com/us/album/pilatus-mountain-of-dragons/1460701955?i=1460702095&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Tolga-Os Janitsjar",
+      "result_piece": "Hymn to the Sun",
+      "recording_title": "Hymn to the Sun-With the Beat of Mother Earth",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/5xanoVNgyUQ0DSqt2CJaU1",
+      "apple_music": "https://music.apple.com/us/album/hymn-to-the-sun-with-the-beat-of-mother-earth/1460701955?i=1460702960&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Tvedestrand Musikkorps",
+      "result_piece": "Isles of the Blessed",
+      "recording_title": "Isles of the Blessed",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/4pI8Tys7ZUhkqrXlHdViFa",
+      "apple_music": "https://music.apple.com/us/album/isles-of-the-blessed/1460701955?i=1460702462&uo=4"
     },
     {
       "year": 2019,
@@ -10796,9 +11646,19 @@
       "band": "Ås og Vestby Musikkorps",
       "result_piece": "subTERRA",
       "recording_title": "subTERRA",
-      "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/subterra/1460693460?i=1460693562&uo=4"
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/4LBu6BmnvNaKpisTDeuGiu",
+      "apple_music": "https://music.apple.com/us/album/subterra/1460701955?i=1460702339&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Åsnes Hornmusikk",
+      "result_piece": "Tower of Babel",
+      "recording_title": "Tower of Babel",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/3bsKKRRH84xLwcveNbl9w7",
+      "apple_music": "https://music.apple.com/us/album/tower-of-babel/1460701955?i=1460702547&uo=4"
     },
     {
       "year": 2019,
@@ -11048,7 +11908,7 @@
       "recording_title": "Edenstrand",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/7AFseW0cwDho3ZSHgtwEfG",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/edenstrand/1460045964?i=1460046287&uo=4"
     },
     {
       "year": 2019,
@@ -11057,8 +11917,8 @@
       "result_piece": "El Camino Real",
       "recording_title": "El Camino Real",
       "album": "NM Janitsjar 2019 - 7 divisjon",
-      "spotify": "https://open.spotify.com/track/487VeYM3aLq8QCeduUN89I",
-      "apple_music": "https://music.apple.com/us/album/el-camino-real/1460693460?i=1460693742&uo=4"
+      "spotify": "https://open.spotify.com/track/7mdleiIM75pitE6dWN35Nu",
+      "apple_music": "https://music.apple.com/us/album/el-camino-real/1460045964?i=1460046288&uo=4"
     },
     {
       "year": 2019,
@@ -11068,7 +11928,7 @@
       "recording_title": "Storbystev",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/7Dw7bhSLVku6FdsGLuDFAH",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/storbystev/1460045964?i=1460046281&uo=4"
     },
     {
       "year": 2019,
@@ -11078,7 +11938,7 @@
       "recording_title": "Einstein",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/5PENLN4GW0mCYRd0lcKfrE",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/einstein/1460045964?i=1460046419&uo=4"
     },
     {
       "year": 2019,
@@ -11088,7 +11948,7 @@
       "recording_title": "Utopia",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/5B9aetrdVRre0pFL0hR3l2",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/utopia/1460045964?i=1460046116&uo=4"
     },
     {
       "year": 2019,
@@ -11098,7 +11958,7 @@
       "recording_title": "Life in the Capital City",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/08EA8J8AV7fst2F9CTGl0y",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/life-in-the-capital-city/1460045964?i=1460046273&uo=4"
     },
     {
       "year": 2019,
@@ -11108,7 +11968,7 @@
       "recording_title": "Music for a Festival",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/5InsgtTYc8UPo1v8eqqR3n",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/music-for-a-festival/1460045964?i=1460046278&uo=4"
     },
     {
       "year": 2019,
@@ -11118,7 +11978,7 @@
       "recording_title": "Iberian Escapedes",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/3fA4sa7Iy8VPwWKniIIsP4",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/iberian-escapedes/1460045964?i=1460046293&uo=4"
     },
     {
       "year": 2019,
@@ -11128,7 +11988,7 @@
       "recording_title": "Sinfonia Noblissima",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/0ztYuDsYOy8RFFwxGBhU1a",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/sinfonia-noblissima/1460045964?i=1460046289&uo=4"
     },
     {
       "year": 2019,
@@ -11138,7 +11998,7 @@
       "recording_title": "Oregon",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/1gSbHg8sBRK96Ns93BUNhK",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/oregon/1460045964?i=1460046434&uo=4"
     },
     {
       "year": 2019,
@@ -11148,7 +12008,7 @@
       "recording_title": "Puszta",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/0kbcRI8oKncfKNF3oRbVxB",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/puszta/1460045964?i=1460046430&uo=4"
     },
     {
       "year": 2019,
@@ -11158,7 +12018,7 @@
       "recording_title": "Blues Mambo",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/775JgqafpCKBoKQk8bmteq",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/blues-mambo/1460045964?i=1460046269&uo=4"
     },
     {
       "year": 2019,
@@ -11168,7 +12028,7 @@
       "recording_title": "Where the River flows - A Historical Triology",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/1v40zLpppDuBkcUB0QtxPJ",
-      "apple_music": "https://music.apple.com/us/album/between-the-two-rivers/1460693460?i=1460694000&uo=4"
+      "apple_music": "https://music.apple.com/us/album/where-the-river-flows-a-historical-triology/1460045964?i=1460046145&uo=4"
     },
     {
       "year": 2019,
@@ -11178,7 +12038,7 @@
       "recording_title": "El Camino Real",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/487VeYM3aLq8QCeduUN89I",
-      "apple_music": "https://music.apple.com/us/album/el-camino-real/1460693460?i=1460693742&uo=4"
+      "apple_music": "https://music.apple.com/us/album/el-camino-real/1460045964?i=1460046144&uo=4"
     },
     {
       "year": 2019,
@@ -11188,7 +12048,7 @@
       "recording_title": "Into the Raging River",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/1Li5RxuN5CSAmkGTsbC8EH",
-      "apple_music": "https://music.apple.com/us/album/into-the-raging-river/1460190452?i=1460190693&uo=4"
+      "apple_music": "https://music.apple.com/us/album/into-the-raging-river/1460045964?i=1460046138&uo=4"
     },
     {
       "year": 2019,
@@ -11198,7 +12058,7 @@
       "recording_title": "Williambyrd Suite (1,3,4 og 6 sats)",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/0Tykh2qY2CG2Q7W6S5CTE2",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/williambyrd-suite-1-3-4-og-6-sats/1460045964?i=1460046423&uo=4"
     },
     {
       "year": 2019,
@@ -11208,7 +12068,7 @@
       "recording_title": "Jupiter Hymn",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/4T07uIJrXljNicSa9VNHAs",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/jupiter-hymn/1460045964?i=1460046121&uo=4"
     },
     {
       "year": 2019,
@@ -11218,7 +12078,7 @@
       "recording_title": "Noah´s Ark",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/76GvvjlVoYFImnKAn53yqI",
-      "apple_music": "https://music.apple.com/us/album/noahs-ark/1460693460?i=1460693471&uo=4"
+      "apple_music": "https://music.apple.com/us/album/noahs-ark/1460045964?i=1460046137&uo=4"
     },
     {
       "year": 2019,
@@ -11385,39 +12245,79 @@
       "division": "1. divisjon",
       "band": "Alvøens Musikkforening",
       "result_piece": "Pinocchio",
-      "recording_title": "Pinocchio (Complete Ed.) Symphonic Suite (Live)",
+      "recording_title": "Pinocchio (Complete Ed.) Symphonic Suite - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/10qqn91tSiqSCNM8q00as4",
       "apple_music": "https://music.apple.com/us/album/pinocchio-complete-ed-symphonic-suite-live/1621096649?i=1621097059&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "1. divisjon",
+      "band": "Asker Musikkorps",
+      "result_piece": "Homenaje a Joaquìn Sorolla Cuados Sinfònicos",
+      "recording_title": "Homenaje a Joaquín SorollaHomenaje a Joaquín Sorolla - Live",
+      "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4qb9lyFSvEP38MvEnowMQn",
+      "apple_music": "https://music.apple.com/us/album/homenaje-a-joaqu%C3%ADn-sorollahomenaje-a-joaqu%C3%ADn-sorolla-live/1621096649?i=1621096650&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "1. divisjon",
+      "band": "Borge Musikkorps",
+      "result_piece": "Symphony in B flat for Concert Band",
+      "recording_title": "Symphony in B-Flat for Band: I. Moderately fast - II. Andantino grazioso - III. Fugue. - Live",
+      "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3ak4zi8BB9ycpfSU8GK8a8",
+      "apple_music": "https://music.apple.com/us/album/symphony-in-b-flat-for-band-i-moderately-fast-ii-andantino/1621096649?i=1621096654&uo=4"
     },
     {
       "year": 2022,
       "division": "1. divisjon",
       "band": "Byneset Musikkorps",
       "result_piece": "Machu Picchu - City in the sky - the mystery of the hidden sun Temple",
-      "recording_title": "Machu Picchu - City in the Sky The Mystery of the Hidden Sun Temple (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/machu-picchu-city-in-the-sky-the-mystery-of/1621078172?i=1621078887&uo=4"
+      "recording_title": "Machu Picchu - City in the Sky The Mystery of the Hidden Sun Temple - Live",
+      "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4Tm0hZzh61HdcWO4uoev3y",
+      "apple_music": "https://music.apple.com/us/album/machu-picchu-city-in-the-sky-the-mystery-of/1621096649?i=1621097314&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "1. divisjon",
+      "band": "Byneset Musikkorps",
+      "result_piece": "Spiritual Planet, 1. og 2. sats",
+      "recording_title": "Spiritual planet: I. Lost Souls - II. Enlightenment - Live",
+      "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/21yv28Ysy29di2m6YAxdvH",
+      "apple_music": "https://music.apple.com/us/album/spiritual-planet-i-lost-souls-ii-enlightenment-live/1621096649?i=1621097303&uo=4"
     },
     {
       "year": 2022,
       "division": "1. divisjon",
       "band": "Nittedal og Hakadal Janitsjar",
       "result_piece": "Selamlik, Op. 48",
-      "recording_title": "Sélamlik, Op. 48 - No. 1 (Live)",
+      "recording_title": "Sélamlik, Op. 48 - No. 1 - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/50jV8TseUGctBabVjGaSqr",
       "apple_music": "https://music.apple.com/us/album/s%C3%A9lamlik-op-48-no-1-live/1621096649?i=1621097048&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "1. divisjon",
+      "band": "Nittedal og Hakadal Janitsjar",
+      "result_piece": "Symphony no. 6",
+      "recording_title": "Sélamlik, Op. 48 - No. 1 - Live",
+      "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/50jV8TseUGctBabVjGaSqr",
+      "apple_music": null
     },
     {
       "year": 2022,
       "division": "1. divisjon",
       "band": "Os Musikkforening",
       "result_piece": "Incantation and Dance",
-      "recording_title": "Incantation and Dance (Live)",
+      "recording_title": "Incantation and Dance - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6NZmieVYlwFfDn9LvFNSRc",
       "apple_music": "https://music.apple.com/us/album/incantation-and-dance-live/1621096649?i=1621097068&uo=4"
     },
     {
@@ -11425,9 +12325,9 @@
       "division": "1. divisjon",
       "band": "Os Musikkforening",
       "result_piece": "Polovetsian Dances from Prince Igor",
-      "recording_title": "Polovtsian Dances from Opera \"Prince Igor\" (Live)",
+      "recording_title": "Polovtsian Dances from Opera \"Prince Igor\" - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/0nT8mHcsFNyarcx49TYfq0",
       "apple_music": "https://music.apple.com/us/album/polovtsian-dances-from-opera-prince-igor-live/1621096649?i=1621097073&uo=4"
     },
     {
@@ -11435,9 +12335,9 @@
       "division": "1. divisjon",
       "band": "Os Musikkforening",
       "result_piece": "Underlige Aftenlufte",
-      "recording_title": "Underlige aftenlufte (Carl Nielsen) [Live]",
+      "recording_title": "Underlige aftenlufte (Carl Nielsen) - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4oB25hVA0IS1ddJbYtC1g0",
       "apple_music": "https://music.apple.com/us/album/underlige-aftenlufte-carl-nielsen-live/1621096649?i=1621097069&uo=4"
     },
     {
@@ -11445,9 +12345,9 @@
       "division": "1. divisjon",
       "band": "Sandefjord Musikkorps",
       "result_piece": "Equus",
-      "recording_title": "Equus - Live",
-      "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/0CKorKD0PwO9OG2PhkNAHf",
+      "recording_title": "Equus - concert band - Live",
+      "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6kmNWud20Q0wN8lfIUdZvt",
       "apple_music": "https://music.apple.com/us/album/equus-concert-band-live/1621096649?i=1621097440&uo=4"
     },
     {
@@ -11455,9 +12355,9 @@
       "division": "1. divisjon",
       "band": "Sandefjord Musikkorps",
       "result_piece": "Festival Overture, Op. 39",
-      "recording_title": "Festival Overture, Op. 39 (Live)",
+      "recording_title": "Festival Overture, Op. 39 - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/1j9BlDrf6IR8wbnBzxm0di",
       "apple_music": "https://music.apple.com/us/album/festival-overture-op-39-live/1621096649?i=1621097439&uo=4"
     },
     {
@@ -11465,20 +12365,60 @@
       "division": "1. divisjon",
       "band": "Sarpsborg Janitsjarkorps",
       "result_piece": "Dance Movements",
-      "recording_title": "Dance Movements (Live)",
+      "recording_title": "Dance Movements - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4XM6beIMUfglr3T6MVo3VT",
       "apple_music": "https://music.apple.com/us/album/dance-movements-live/1621096649?i=1621097299&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "1. divisjon",
+      "band": "Skjold Nesttun Janitsjar",
+      "result_piece": "Peter Pan",
+      "recording_title": "Peter Pan: I. The Open Window. The Shadow. We Fly - II. Neverland - III. El Hogar Feliz. El cuento de Wendy - IV. The Redskins. The Kidnapping of the Children. - Live",
+      "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/61qw61VPtu91uLyyHLMNhF",
+      "apple_music": "https://music.apple.com/us/album/peter-pan-i-the-open-window-the-shadow-we-fly/1621096649?i=1621097287&uo=4"
     },
     {
       "year": 2022,
       "division": "1. divisjon",
       "band": "Stavanger Musikkorps av 1919",
       "result_piece": "Zenith of the Maya",
-      "recording_title": "Zenith of the Maya (Live)",
+      "recording_title": "Zenith of the Maya - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/2FeWqUvJt7Y2UFKu3AAvPB",
       "apple_music": "https://music.apple.com/us/album/zenith-of-the-maya-live/1621096649?i=1621097451&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Bispehaugen Ungdomskorps",
+      "result_piece": "Tales and Legends, 1. og 3. sats",
+      "recording_title": "Tales and Legends: I. The Witch Catillon - III. The Count Michael - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1Q4154TRQWkbNqT7vdGcOy",
+      "apple_music": "https://music.apple.com/us/album/tales-and-legends-i-the-witch-catillon-iii-the/1621082841?i=1621082846&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Bjølsen Ungdomskorps",
+      "result_piece": "Jungla, Poema ambientado en la Selva Africana",
+      "recording_title": "Jungla (Poem Set in the African Jungle, for Symphonic Band) - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7oJO6HXWOHMZmhkk4l2KA1",
+      "apple_music": "https://music.apple.com/us/album/jungla-poem-set-in-the-african-jungle-for-symphonic/1621082841?i=1621083215&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Drammen Konsertorkester",
+      "result_piece": "Awayday",
+      "recording_title": "Awayday - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5L7574bRchb1B6qiKPG5tL",
+      "apple_music": "https://music.apple.com/us/album/awayday-live/1621082841?i=1621083517&uo=4"
     },
     {
       "year": 2022,
@@ -11486,99 +12426,229 @@
       "band": "Drammen Konsertorkester",
       "result_piece": "Det gamle kvernhuset",
       "recording_title": "Det Gamle Kvernhuset, Op.204 (windband) - Live",
-      "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7iTXYdYxPN7EUn06rid2vj",
-      "apple_music": "https://music.apple.com/us/album/det-gamle-kvernhuset-op-204-windband-live/1621077640?i=1621079387&uo=4"
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6UNyQvY2DEjMs7TmQIq5Md",
+      "apple_music": "https://music.apple.com/us/album/det-gamle-kvernhuset-op-204-windband-live/1621082841?i=1621083523&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Drammen Konsertorkester",
+      "result_piece": "Nitro",
+      "recording_title": "Nitro - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/14xs9d7AerL9QDItqBcdLa",
+      "apple_music": "https://music.apple.com/us/album/nitro-live/1621082841?i=1621083527&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Gjøvik Bykorps",
+      "result_piece": "Elements of Nature",
+      "recording_title": "Elements of Nature - Suite - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3i9qtKJdewT6rAA4USYoR4",
+      "apple_music": "https://music.apple.com/us/album/elements-of-nature-suite-live/1621082841?i=1621083191&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Hov Musikkorps",
+      "result_piece": "Paris Sketches",
+      "recording_title": "Paris Sketches Homages for Wind Band: I. Saint Germain-des-Prés - II. Pigalle - III. Père Lachaise - IV. Les Halles - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3mYi1NH78DcDADRMqUnyaQ",
+      "apple_music": "https://music.apple.com/us/album/paris-sketches-homages-for-wind-band-i-saint-germain/1621082841?i=1621083769&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Hovin Musikkorps",
+      "result_piece": "Battle of Hearts",
+      "recording_title": "Battle of Hearts (Symphonic Poem) - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/65hOnjOtXk3xmDPaBR11sX",
+      "apple_music": "https://music.apple.com/us/album/battle-of-hearts-symphonic-poem-live/1621082841?i=1621083454&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Lungegaardens Musikkorps",
       "result_piece": "Between the Two Rivers",
-      "recording_title": "Between the Two Rivers (Variations on Ein Feste Burg) Concert Band (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/between-the-two-rivers-variations-on-ein-feste-burg/1621078172?i=1621079259&uo=4"
+      "recording_title": "Between the Two Rivers (Variations on Ein Feste Burg) Concert Band - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/33YmJ13kkqmwdimcvduPAs",
+      "apple_music": "https://music.apple.com/us/album/between-the-two-rivers-variations-on-ein-feste-burg/1621082841?i=1621084073&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Lørenskog Musikkorps",
+      "result_piece": "Les Trois Notes du Japon",
+      "recording_title": "Les trois notes du Japon: I. La danse des grues (Tancho cranes' mating dance) - II. La riviere enneigee (Snowy river) - III. Le fete du feu (Nebuta festival) - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/13q0KaKQkIKmD06Zc2plWl",
+      "apple_music": "https://music.apple.com/us/album/les-trois-notes-du-japon-i-la-danse-des-grues-tancho/1621082841?i=1621083199&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Sandvikens Ungdomskorps",
+      "result_piece": "Festiva Jubiloso",
+      "recording_title": "Festiva Jublioso - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7uCr3f0hvmyrSIjvXmziUW",
+      "apple_music": "https://music.apple.com/us/album/festiva-jublioso-live/1621082841?i=1621083532&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Sandvikens Ungdomskorps",
+      "result_piece": "Symphonic Songs for Band",
+      "recording_title": "Symphonic Songs for Band: I. Serenade - II. Spiritual - III. Celebration - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/62TdJVVv9klA1HpbPLb7Rr",
+      "apple_music": "https://music.apple.com/us/album/symphonic-songs-for-band-i-serenade-ii-spiritual-iii/1621082841?i=1621083541&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Strindheim Janitsjar",
+      "result_piece": "Fanfares and Fantasies",
+      "recording_title": "Fanfares and Fantasies - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2tBU8EsfQxP0sSGpwIEnVw",
+      "apple_music": "https://music.apple.com/us/album/fanfares-and-fantasies-live/1621082841?i=1621083209&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Strindheim Janitsjar",
+      "result_piece": "Symphonic Metamorphosis of themes by Carl Maria von Weber, 4. sats March",
+      "recording_title": "Symphonic Metamorphosis on Themes by Carl Maria von Weber (Concert Band): IV. March - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7p1SCfpjKfPPzAHlxXbLvd",
+      "apple_music": "https://music.apple.com/us/album/symphonic-metamorphosis-on-themes-by-carl-maria-von/1621082841?i=1621083204&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Sykkylven Janitsjarorkester",
+      "result_piece": "Angels in the Architecture",
+      "recording_title": "Angels in the Architecture - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1Yj4SsG4tAUtgoTs4ffbPA",
+      "apple_music": "https://music.apple.com/us/album/angels-in-the-architecture-live/1621082841?i=1621084079&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Tromsø Orkesterforenings Janitsjarkorps",
+      "result_piece": "Egmont",
+      "recording_title": "Egmont - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0SuA4UzFL48INIStJDTnRA",
+      "apple_music": "https://music.apple.com/us/album/egmont-live/1621082841?i=1621083761&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Tønsberg Janitsjarkorps",
+      "result_piece": "The Kings Go Forth",
+      "recording_title": "The Kings go Forth - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0GWP2PL7yK76fzwO08HsfR",
+      "apple_music": "https://music.apple.com/us/album/the-kings-go-forth-live/1621082841?i=1621083783&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Vestre Aker Musikkorps",
+      "result_piece": "Dance Suite",
+      "recording_title": "Dance Suite: I. Moderato - II. Allegro molto - III. Allegro Vivace - IV. Molto tranquillo - V. Comodo - VI. Finale. Allegro - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7K9ptaD8tFnn5K6SMtauJB",
+      "apple_music": "https://music.apple.com/us/album/dance-suite-i-moderato-ii-allegro-molto-iii-allegro/1621082841?i=1621084082&uo=4"
     },
     {
       "year": 2022,
@@ -11586,19 +12656,19 @@
       "band": "Ådalsbruk Musikkforening",
       "result_piece": "Firefly",
       "recording_title": "FIREFLY for symphonic winds & percussion - Live",
-      "album": "Nm Janitsjar 2022 - 7. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1uxievZeGCaeyTUuM8irx7",
-      "apple_music": null
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/32W9XHoxc0zbEq7G6kHeVD",
+      "apple_music": "https://music.apple.com/us/album/firefly-for-symphonic-winds-percussion-live/1621082841?i=1621083434&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Ådalsbruk Musikkforening",
       "result_piece": "Terra Australis",
-      "recording_title": "Terra Mystica - Live",
-      "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4F2Nz1CrCjgrm6DjO69TW0",
-      "apple_music": null
+      "recording_title": "Terra Australis - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1Vh2lt3Oakxq84fEYxrUV2",
+      "apple_music": "https://music.apple.com/us/album/terra-australis-live/1621082841?i=1621083444&uo=4"
     },
     {
       "year": 2022,
@@ -11643,12 +12713,32 @@
     {
       "year": 2022,
       "division": "3. divisjon",
+      "band": "Fet Janitsjar",
+      "result_piece": "Armenian Dances, Part 1",
+      "recording_title": "Armenian Dances Pt 1 - Live",
+      "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2vECIIDzXppJVzOosOEVr1",
+      "apple_music": "https://music.apple.com/us/album/armenian-dances-pt-1-live/1621077640?i=1621077805&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "3. divisjon",
       "band": "Fåberg Musikkforening",
       "result_piece": "Traveler",
       "recording_title": "Traveler - Live",
       "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/7jlKPkCGDtlQtC1SYlWX3E",
       "apple_music": "https://music.apple.com/us/album/traveler-live/1621077640?i=1621078516&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "3. divisjon",
+      "band": "Halsen Musikkforening",
+      "result_piece": "Aurora Borealis",
+      "recording_title": "Aurora Borealis - Live",
+      "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4qkVLPB3KDd7QwQHIXUmvp",
+      "apple_music": "https://music.apple.com/us/album/aurora-borealis-live/1621077640?i=1621077797&uo=4"
     },
     {
       "year": 2022,
@@ -11669,6 +12759,26 @@
       "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/3hbkixMSH7krRqxjEVmZR6",
       "apple_music": "https://music.apple.com/us/album/hymn-to-the-sun-with-the-beat-of-mother-earth-live/1621077640?i=1621078246&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "3. divisjon",
+      "band": "Musikklaget Brage",
+      "result_piece": "Ignition",
+      "recording_title": "Ignition - Live",
+      "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1Pfv2mYLE6vn7UXJ6KHfNf",
+      "apple_music": "https://music.apple.com/us/album/ignition-live/1621077640?i=1621077814&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "3. divisjon",
+      "band": "Musikklaget Ulf",
+      "result_piece": "Music for a Festival",
+      "recording_title": "Music for a Festival - Live",
+      "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3Gdu77TmT5ubCymxN9k76H",
+      "apple_music": "https://music.apple.com/us/album/music-for-a-festival-live/1621077640?i=1621079618&uo=4"
     },
     {
       "year": 2022,
@@ -11773,6 +12883,16 @@
     {
       "year": 2022,
       "division": "4. divisjon",
+      "band": "Byåsen Musikkorps",
+      "result_piece": "Music for a Festival",
+      "recording_title": "Music for a Festival - Live",
+      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3MGHWAtsbp6bJcTsTQ2lKA",
+      "apple_music": "https://music.apple.com/us/album/music-for-a-festival-live/1621078172?i=1621079274&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "4. divisjon",
       "band": "Eidsvoll Janitsjarkorps",
       "result_piece": "Tower of Babel",
       "recording_title": "The Tower of Babel - Live",
@@ -11803,11 +12923,21 @@
     {
       "year": 2022,
       "division": "4. divisjon",
+      "band": "Oppegård Janitsjar",
+      "result_piece": "Armenian Dances, Part 1",
+      "recording_title": "Armenian Dances - Live",
+      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4C6tfYqDpxAih8TXbuPNqo",
+      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "4. divisjon",
       "band": "Oslo Postorkester",
       "result_piece": "Lincolnshire Posy, 2. sats",
-      "recording_title": "Lincolshire Posy: II. Horkstow Grange (Live)",
+      "recording_title": "Lincolshire Posy: II. Horkstow Grange - Live",
       "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/0KoWTMuRptwhMRdCmCgEAj",
       "apple_music": "https://music.apple.com/us/album/lincolshire-posy-ii-horkstow-grange-live/1621078172?i=1621079603&uo=4"
     },
     {
@@ -11872,6 +13002,16 @@
     },
     {
       "year": 2022,
+      "division": "4. divisjon",
+      "band": "Østre Gausdal Musikkforening",
+      "result_piece": "Armenian Dances, Part 1",
+      "recording_title": "Armenian Dances Pt 1 - Live",
+      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/58FUDxTyInq4ABt00lahVc",
+      "apple_music": "https://music.apple.com/us/album/armenian-dances-pt-1-live/1621078172?i=1621079280&uo=4"
+    },
+    {
+      "year": 2022,
       "division": "5. divisjon",
       "band": "Alvdal-Tynset Janitsjarkorps",
       "result_piece": "Deliverance",
@@ -11883,12 +13023,42 @@
     {
       "year": 2022,
       "division": "5. divisjon",
+      "band": "Eina Musikkforening",
+      "result_piece": "Lake of the Moon",
+      "recording_title": "Lake of The Moon (Wind Band) - Live",
+      "album": "Nm Janitsjar 2022 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6E2GKc2WO4Z5hEfOrndDAd",
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-wind-band-live/1621078046?i=1621078407&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "5. divisjon",
+      "band": "Hamar Musikkorps",
+      "result_piece": "Hispanola",
+      "recording_title": "Hispaniola - Live",
+      "album": "Nm Janitsjar 2022 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5E6XF2cmxLDZmyJagXZs6v",
+      "apple_music": "https://music.apple.com/us/album/hispaniola-live/1621078046?i=1621078392&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "5. divisjon",
       "band": "Hønefoss Ungdomskorps",
       "result_piece": "A Little Stress Music",
       "recording_title": "A little stress music - Satire in four parts: I. Rush Hour - II. Promenade Waltz - III. Romance - IV. Monday Morning - Live",
       "album": "Nm Janitsjar 2022 - 5. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2bTMzz9QUklhPopbFDaSBe",
       "apple_music": "https://music.apple.com/us/album/a-little-stress-music-satire-in-four-parts-i-rush/1621078046?i=1621078406&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "5. divisjon",
+      "band": "Jernbanens Musikkorps Oslo",
+      "result_piece": "Bridges over the River Cam",
+      "recording_title": "Bridges Over the River Cam - Live",
+      "album": "Nm Janitsjar 2022 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5gW8mNVioDIkl3JFRNX7uI",
+      "apple_music": "https://music.apple.com/us/album/bridges-over-the-river-cam-live/1621078046?i=1621078639&uo=4"
     },
     {
       "year": 2022,
@@ -11917,8 +13087,18 @@
       "result_piece": "The Adventures of Baron Munchausen",
       "recording_title": "The Adventures of Baron Munchausen: Journey Through the Earth - Live",
       "album": "Nm Janitsjar 2022 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1qMJM4ZsU0IFxPagxKlQlT",
-      "apple_music": "https://music.apple.com/us/album/the-adventures-of-baron-munchausen-journey-through/1621078046?i=1621078399&uo=4"
+      "spotify": "https://open.spotify.com/track/7qFbPMsUY6NkSaI5PaqVen",
+      "apple_music": "https://music.apple.com/us/album/the-adventures-of-baron-munchausen-journey-through/1621078046?i=1621078629&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "5. divisjon",
+      "band": "Rælingen Musikklag",
+      "result_piece": "Music for a Festival",
+      "recording_title": "Music for a Festival - Live",
+      "album": "Nm Janitsjar 2022 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1a5zMjzOzi2DcBctjpPYX7",
+      "apple_music": "https://music.apple.com/us/album/music-for-a-festival-live/1621078046?i=1621078404&uo=4"
     },
     {
       "year": 2022,
@@ -11945,9 +13125,9 @@
       "division": "6. divisjon",
       "band": "Drøbak Musikkorps",
       "result_piece": "A Little Stress Music",
-      "recording_title": "A little stress music - Satire in four parts: I. Rush Hour - II. Promenade Waltz - III. Romance - IV. Monday Morning (Live)",
+      "recording_title": "A little stress music - Satire in four parts: I. Rush Hour - II. Promenade Waltz - III. Romance - IV. Monday Morning - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/3cCT3wszpFmWvIFbiWZAyn",
       "apple_music": "https://music.apple.com/us/album/a-little-stress-music-satire-in-four-parts-i-rush/1621077976?i=1621078812&uo=4"
     },
     {
@@ -11955,9 +13135,9 @@
       "division": "6. divisjon",
       "band": "Follebu og Vestre Gausdal Musikkforening",
       "result_piece": "Heaven's Light",
-      "recording_title": "Heaven's light (Live)",
+      "recording_title": "Heaven´s light - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/5ot6hVQ1LnnUJ1Hp1TzSHN",
       "apple_music": "https://music.apple.com/us/album/heavens-light-live/1621077976?i=1621078806&uo=4"
     },
     {
@@ -11966,8 +13146,8 @@
       "band": "Follebu og Vestre Gausdal Musikkforening",
       "result_piece": "Into the Joy of Spring",
       "recording_title": "Into the joy of spring: I. Winter's Fury - II. Spring's Awakening - III. Celebration Of Joy - Live",
-      "album": "Nm Janitsjar 2022 - 7. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/32N2mDkwReYUuLnI4eOPgL",
+      "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4ci5kT0QJpY1hNhZlPfWuh",
       "apple_music": "https://music.apple.com/us/album/into-the-joy-of-spring-i-winters-fury-ii/1621077976?i=1621078501&uo=4"
     },
     {
@@ -11975,9 +13155,9 @@
       "division": "6. divisjon",
       "band": "Hommelvik Musikkorps",
       "result_piece": "Eine Kleine Yiddishe Ragmusik",
-      "recording_title": "Eine Kleine Yiddische Ragmusik - Live",
-      "album": "Nm Janitsjar 2022 - 7. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7xcnkAwBBgwZZxfzKyCsR4",
+      "recording_title": "Eine Kleine Yiddishe Ragmusik - Live",
+      "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5UHHiUypaOcDyzQQWmHOFk",
       "apple_music": "https://music.apple.com/us/album/eine-kleine-yiddishe-ragmusik-live/1621077976?i=1621078192&uo=4"
     },
     {
@@ -11985,9 +13165,9 @@
       "division": "6. divisjon",
       "band": "Hommelvik Musikkorps",
       "result_piece": "Lord Tullamore",
-      "recording_title": "Lord Tullamore (Live)",
+      "recording_title": "Lord Tullamore - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4L48ftPz684CEjSIHLcTKm",
       "apple_music": "https://music.apple.com/us/album/lord-tullamore-live/1621077976?i=1621078205&uo=4"
     },
     {
@@ -11995,9 +13175,9 @@
       "division": "6. divisjon",
       "band": "Jevnaker Ungdomskorps",
       "result_piece": "Diogenes",
-      "recording_title": "Diogenes (Live)",
+      "recording_title": "Diogenes - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/0hK7fUwlAxwRbGnMFJVHdu",
       "apple_music": "https://music.apple.com/us/album/diogenes-live/1621077976?i=1621078485&uo=4"
     },
     {
@@ -12005,9 +13185,9 @@
       "division": "6. divisjon",
       "band": "Klæbu Musikkorps",
       "result_piece": "Puszta (Four Gypsi Dances)",
-      "recording_title": "Puszta (Live)",
+      "recording_title": "Puszta - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/5EYgP9usqAkjH11oAapakR",
       "apple_music": "https://music.apple.com/us/album/puszta-live/1621077976?i=1621077983&uo=4"
     },
     {
@@ -12016,8 +13196,8 @@
       "band": "Lørenskog Blåseensemble",
       "result_piece": "Banja Luka",
       "recording_title": "Banja Luka - Live",
-      "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/47WsrzsUIjyiqGc0MEPKT5",
+      "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1rwORJSNax4dSLaQeJSx2M",
       "apple_music": "https://music.apple.com/us/album/banja-luka-live/1621077976?i=1621077987&uo=4"
     },
     {
@@ -12025,9 +13205,9 @@
       "division": "6. divisjon",
       "band": "Moss og omegn Janitsjar",
       "result_piece": "Breaking Point",
-      "recording_title": "Breaking Point (Live)",
+      "recording_title": "Breaking Point - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/1sr58TUZX0OQgLQHCaCP2W",
       "apple_music": "https://music.apple.com/us/album/breaking-point-live/1621077976?i=1621078190&uo=4"
     },
     {
@@ -12035,9 +13215,9 @@
       "division": "6. divisjon",
       "band": "Moss og omegn Janitsjar",
       "result_piece": "Mercury March",
-      "recording_title": "Mercury (Live)",
+      "recording_title": "Mercury - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/42aakeOwlqU1zRIMoqe58r",
       "apple_music": "https://music.apple.com/us/album/mercury-live/1621077976?i=1621078187&uo=4"
     },
     {
@@ -12045,9 +13225,9 @@
       "division": "6. divisjon",
       "band": "Namsos Musikkorps",
       "result_piece": "Hispanola",
-      "recording_title": "Hispaniola (Live)",
-      "album": "Nm Janitsjar 2022 - 5. divisjon (Live)",
-      "spotify": null,
+      "recording_title": "Hispaniola (Concert Band) - Live",
+      "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/674oOjCSIWBulJfhYQUyT5",
       "apple_music": "https://music.apple.com/us/album/hispaniola-live/1621078046?i=1621078392&uo=4"
     },
     {
@@ -12055,9 +13235,9 @@
       "division": "6. divisjon",
       "band": "Skatval Hornmusikklag",
       "result_piece": "Pilatus: Mountain of Dragons",
-      "recording_title": "Pilatus: Mountain of Dragons (Live)",
+      "recording_title": "Pilatus: Mountain of Dragons - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4A4Q9YAF3HRR20XlcDUfa9",
       "apple_music": "https://music.apple.com/us/album/pilatus-mountain-of-dragons-live/1621077976?i=1621078490&uo=4"
     },
     {
@@ -12065,9 +13245,9 @@
       "division": "6. divisjon",
       "band": "Strinda Ungdomskorps",
       "result_piece": "Skamslått",
-      "recording_title": "Skamslått (Live)",
+      "recording_title": "Skamslått - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/14FXTfqrrQxs8XR3vX6kGc",
       "apple_music": "https://music.apple.com/us/album/skamsl%C3%A5tt-live/1621077976?i=1621078183&uo=4"
     },
     {
@@ -12075,9 +13255,9 @@
       "division": "6. divisjon",
       "band": "Strinda Ungdomskorps",
       "result_piece": "Tognum Power",
-      "recording_title": "Tognum Power (Live)",
+      "recording_title": "Tognum Power - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/7B9S0VjD74MzfXaECIA4MG",
       "apple_music": "https://music.apple.com/us/album/tognum-power-live/1621077976?i=1621078185&uo=4"
     },
     {
@@ -12085,9 +13265,9 @@
       "division": "6. divisjon",
       "band": "Vålerenga Janitsjarkorps",
       "result_piece": "Utopia",
-      "recording_title": "Utopia (Live)",
+      "recording_title": "Utopia - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/23DOiW5Djz9mKuDD5HSzaM",
       "apple_music": "https://music.apple.com/us/album/utopia-live/1621077976?i=1621078807&uo=4"
     },
     {
@@ -12095,9 +13275,9 @@
       "division": "6. divisjon",
       "band": "Åndalsnes Musikkforening",
       "result_piece": "Time for Celebration",
-      "recording_title": "Time for Celebration (Live)",
+      "recording_title": "Time for Celebration - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/0guzTGjSufLdt08uMlFt98",
       "apple_music": "https://music.apple.com/us/album/time-for-celebration-live/1621077976?i=1621078496&uo=4"
     },
     {
@@ -12258,6 +13438,26 @@
       "recording_title": "69 marching bars of leftovers from an old century - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/6ceylNdfTlv8ooE18fFh6f",
+      "apple_music": "https://music.apple.com/us/album/69-marching-bars-of-leftovers-from-an-old-century-live/1621715628?i=1621715637&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "Goldberg 2012",
+      "recording_title": "Goldberg 2012 - Live",
+      "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/10qvtEtTev4rVUVxJhn8Cu",
+      "apple_music": "https://music.apple.com/us/album/goldberg-2012-live/1621715628?i=1621715645&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "King Mangoberry, 1. og 3. sats",
+      "recording_title": "Goldberg 2012 - Live",
+      "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/10qvtEtTev4rVUVxJhn8Cu",
       "apple_music": null
     },
     {
@@ -12268,7 +13468,7 @@
       "recording_title": "Sinfonia di Soffiatori nr 3 - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/6PP5397kSeWQjlCjcAAr2c",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/sinfonia-di-soffiatori-nr-3-live/1621715628?i=1621716049&uo=4"
     },
     {
       "year": 2022,
@@ -12278,7 +13478,7 @@
       "recording_title": "Equus - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/0CKorKD0PwO9OG2PhkNAHf",
-      "apple_music": "https://music.apple.com/us/album/equus-concert-band-live/1621096649?i=1621097440&uo=4"
+      "apple_music": "https://music.apple.com/us/album/equus-live/1621715628?i=1621716046&uo=4"
     },
     {
       "year": 2022,
@@ -12288,7 +13488,7 @@
       "recording_title": "Instant Music - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/4EA6PQviVmmq5vzAeQ9EGr",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/instant-music-live/1621715628?i=1621716044&uo=4"
     },
     {
       "year": 2022,
@@ -12298,7 +13498,27 @@
       "recording_title": "Extreme make-over: Metamorphoses on a Theme - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/0bZyWFWbF0BphFInwdzG7U",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/extreme-make-over-metamorphoses-on-a-theme-live/1621715628?i=1621716244&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "Elite",
+      "band": "Mo Hornmusikk",
+      "result_piece": "Symphony no. 6, A Cotswold Symphony",
+      "recording_title": "A Cotswold Symphony, op. 109b - Live",
+      "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3uTDn0WeyyfumFU36CbMxm",
+      "apple_music": "https://music.apple.com/us/album/a-cotswold-symphony-op-109b-live/1621715628?i=1621716429&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "Elite",
+      "band": "Musikkforeningen Nidarholm",
+      "result_piece": "Danse Satanique",
+      "recording_title": "Danse Satanique - Live",
+      "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2QK8yu2GQMTJU0Sel1mNOP",
+      "apple_music": "https://music.apple.com/us/album/danse-satanique-live/1621715628?i=1621716226&uo=4"
     },
     {
       "year": 2022,
@@ -12308,7 +13528,7 @@
       "recording_title": "Mountain Song and Arias - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/1DZK70ocrXP6sKNr4DMHuY",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/mountain-song-and-arias-live/1621715628?i=1621716060&uo=4"
     },
     {
       "year": 2022,
@@ -12318,7 +13538,7 @@
       "recording_title": "Symfony no.3: Variations on the Porazzi Theme of Wagner - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/3Z66UgtlvidzU4vSDc59zD",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/symfony-no-3-variations-on-the-porazzi-theme-of-wagner-live/1621715628?i=1621716229&uo=4"
     },
     {
       "year": 2022,
@@ -12328,7 +13548,7 @@
       "recording_title": "Macbeth - Music to Act 1 of Shakespeares play - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/1KEq8w928bFRosn2UzDFjD",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/macbeth-music-to-act-1-of-shakespeares-play-live/1621715628?i=1621716441&uo=4"
     },
     {
       "year": 2022,
@@ -12338,7 +13558,7 @@
       "recording_title": "Organ Sonata No.4, BWV 528, II: Andante [Adagio] - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/2W3zm3Zk8mxtDDUayCkr9o",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/organ-sonata-no-4-bwv-528-ii-andante-adagio-live/1621715628?i=1621716438&uo=4"
     },
     {
       "year": 2022,
@@ -12348,7 +13568,7 @@
       "recording_title": "Aulos symphony - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/1VarjdRGgr4DmGNM0PfqnI",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/aulos-symphony-live/1621715628?i=1621715631&uo=4"
     },
     {
       "year": 2023,
@@ -13328,7 +14548,7 @@
       "recording_title": "Eldorado - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5U6YW7F7qhaPrAhLReBNrX",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/eldorado-live/1681182666?i=1681183341&uo=4"
     },
     {
       "year": 2023,
@@ -13338,7 +14558,7 @@
       "recording_title": "The Adventures of Baron Munchausen - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1trqi4dV0CoQV2lD2KXNdL",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/the-adventures-of-baron-munchausen-live/1681182666?i=1681183083&uo=4"
     },
     {
       "year": 2023,
@@ -13348,7 +14568,7 @@
       "recording_title": "Ross Roy - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/73oWqEFJJCivVgIziQmF93",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/ross-roy-live/1681182666?i=1681184275&uo=4"
     },
     {
       "year": 2023,
@@ -13358,7 +14578,7 @@
       "recording_title": "Where Eagles Soar - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/16F3ZY4nKu6VjRjKUVBSCb",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/where-eagles-soar-live/1681182666?i=1681184281&uo=4"
     },
     {
       "year": 2023,
@@ -13368,7 +14588,7 @@
       "recording_title": "First Suite for Military Band, No. 1: Chaconne - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6xasp3p4B7RAOU8sCytGor",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/first-suite-for-military-band-no-1-chaconne-live/1681182666?i=1681182675&uo=4"
     },
     {
       "year": 2023,
@@ -13378,7 +14598,7 @@
       "recording_title": "Les Parapluies de Cherboourg - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/3BjsUrG2yLUJFloDqzo9hv",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/les-parapluies-de-cherboourg-live/1681182666?i=1681183079&uo=4"
     },
     {
       "year": 2023,
@@ -13388,7 +14608,7 @@
       "recording_title": "Samtidig, ein annan stad enn no - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/4jMcDsmMv6UbsBWZ8m6Sbr",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/samtidig-ein-annan-stad-enn-no-live/1681182666?i=1681184043&uo=4"
     },
     {
       "year": 2023,
@@ -13398,7 +14618,7 @@
       "recording_title": "Edenstrand - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1G6UgyIu0JYbLTcmXXMRud",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/edenstrand-live/1681182666?i=1681184032&uo=4"
     },
     {
       "year": 2023,
@@ -13408,7 +14628,7 @@
       "recording_title": "Victory: Samtidig, ein annan stad enn no - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6HnDPIg0I7EPzNOKqP6GcR",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/victory-samtidig-ein-annan-stad-enn-no-live/1681182666?i=1681184034&uo=4"
     },
     {
       "year": 2023,
@@ -13418,7 +14638,7 @@
       "recording_title": "Music for a Solemnity - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1p4psz5bB4voVUUTESFjNt",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/music-for-a-solemnity-live/1681182666?i=1681183789&uo=4"
     },
     {
       "year": 2023,
@@ -13428,7 +14648,7 @@
       "recording_title": "A Malvern Suite - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5VNh1uQps8zh1GK6rSIb2e",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/a-malvern-suite-live/1681182666?i=1681183796&uo=4"
     },
     {
       "year": 2023,
@@ -13438,7 +14658,7 @@
       "recording_title": "Armenian Dances - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0CGoCMusnQtO7wutKcrqVv",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1681182666?i=1681183631&uo=4"
     },
     {
       "year": 2023,
@@ -13448,7 +14668,7 @@
       "recording_title": "Dawn of a New Day - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/7h0n8AiiEuvu7vAnimK4K0",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/dawn-of-a-new-day-live/1681182666?i=1681183793&uo=4"
     },
     {
       "year": 2023,
@@ -13458,7 +14678,7 @@
       "recording_title": "Persis - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6b9uw3Ihnu4oCcE0ymku4p",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/persis-live/1681182666?i=1681183794&uo=4"
     },
     {
       "year": 2023,
@@ -13468,7 +14688,7 @@
       "recording_title": "Prelude, Siciliano and Rondo - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2qe6oZ9txFtcCvhhs5ptlq",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/prelude-siciliano-and-rondo-live/1681182666?i=1681183338&uo=4"
     },
     {
       "year": 2023,
@@ -13478,7 +14698,7 @@
       "recording_title": "Street Tango - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/4u5aWaD4uskfwRufAntttX",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/street-tango-live/1681182666?i=1681183090&uo=4"
     },
     {
       "year": 2023,
@@ -13488,7 +14708,7 @@
       "recording_title": "D-day - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5sEJceG9bpjewVr6mMAdQY",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/d-day-live/1681182666?i=1681183087&uo=4"
     },
     {
       "year": 2023,
@@ -13498,7 +14718,7 @@
       "recording_title": "Eine Kleine Yiddishe Ragmusik - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0PxAJ3IPmpc2CaNRuIo9Oo",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/eine-kleine-yiddishe-ragmusik-live/1681182666?i=1681184269&uo=4"
     },
     {
       "year": 2023,
@@ -13508,7 +14728,7 @@
       "recording_title": "Tales and Myths of Gothia - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2xUA2neXltPO9gpaP9of58",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/tales-and-myths-of-gothia-live/1681182666?i=1681184271&uo=4"
     },
     {
       "year": 2023,
@@ -13518,7 +14738,7 @@
       "recording_title": "Street Tango - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2jcFxGDnGD1vir8uA6vWhF",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/street-tango-live/1681182666?i=1681183607&uo=4"
     },
     {
       "year": 2023,
@@ -13528,7 +14748,7 @@
       "recording_title": "Tales and Myths of Gothia - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/63i0Bn9xdEgS4F7h5fcmBQ",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/tales-and-myths-of-gothia-live/1681182666?i=1681183362&uo=4"
     },
     {
       "year": 2023,
@@ -13538,7 +14758,7 @@
       "recording_title": "Pilatus: Mountain of Dragons - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6TiDAJWvAeGB4qWeMVdKCD",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/pilatus-mountain-of-dragons-live/1681182666?i=1681184267&uo=4"
     },
     {
       "year": 2023,
@@ -13945,9 +15165,9 @@
       "division": "1. divisjon",
       "band": "Borge Musikkorps",
       "result_piece": "Divertimento for Band, 4., 5. og 6. sats",
-      "recording_title": "Divertimento for band, Op42: IV, V, VI (Live)",
+      "recording_title": "Divertimento for band, Op42: IV, V, VI - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/33QJtc31DN66AM02vNAmEu",
       "apple_music": "https://music.apple.com/us/album/divertimento-for-band-op42-iv-v-vi-live/1737793406?i=1737793626&uo=4"
     },
     {
@@ -13955,9 +15175,9 @@
       "division": "1. divisjon",
       "band": "Borge Musikkorps",
       "result_piece": "Konzertmusik Für Blasorchester",
-      "recording_title": "Konzertmusik fûr Blasorchester, Op.41 (Live)",
+      "recording_title": "Konzertmusik fûr Blasorchester, Op.41 - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/2ZBh6XAKwsbBcPiiPuHuFc",
       "apple_music": "https://music.apple.com/us/album/konzertmusik-f%C3%BBr-blasorchester-op-41-live/1737793406?i=1737793623&uo=4"
     },
     {
@@ -13965,29 +15185,59 @@
       "division": "1. divisjon",
       "band": "Kolbotn Konsertorkester",
       "result_piece": "D'un Soir Triste",
-      "recording_title": "D'un soir triste (Live)",
+      "recording_title": "D´un soir triste - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6aFVkIrBMqu5KB72lATGdu",
       "apple_music": "https://music.apple.com/us/album/dun-soir-triste-live/1737793406?i=1737794032&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "1. divisjon",
+      "band": "Kolbotn Konsertorkester",
+      "result_piece": "Norsk Rapsodi nr. 1",
+      "recording_title": "Rhapsody Norvegienne No. 1 - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6XUcT1hbYq16Er8Tpwb2gv",
+      "apple_music": "https://music.apple.com/us/album/rhapsody-norvegienne-no-1-live/1737793406?i=1737794034&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Kolbu Janitsjarkorps",
       "result_piece": "Equus",
-      "recording_title": "Equus (Live)",
+      "recording_title": "Equus - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/1jwvYcBcGMZpDqiWTt7qjj",
       "apple_music": "https://music.apple.com/us/album/equus-live/1737793406?i=1737794358&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "1. divisjon",
+      "band": "Kolbu Janitsjarkorps",
+      "result_piece": "Fanfare and Choral",
+      "recording_title": "Fanfare og koral - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/12loXN9XQuS1uqZQmYHcJ6",
+      "apple_music": "https://music.apple.com/us/album/fanfare-og-koral-live/1737793406?i=1737794055&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "1. divisjon",
+      "band": "Lørenskog Musikkorps",
+      "result_piece": "Symphony No IV: Bookmarks from Japan",
+      "recording_title": "Bookmarks from Japan - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2kTuRHeSmbmnbRz4ytMIMO",
+      "apple_music": "https://music.apple.com/us/album/bookmarks-from-japan-live/1737793406?i=1737794037&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Nittedal og Hakadal Janitsjar",
       "result_piece": "Symphony for Wind Orchestra",
-      "recording_title": "Symphony for Wind Orchestra - Montage (Live)",
+      "recording_title": "Symphony for Wind Orchestra - Montage - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/2JJ8BQICgwcnBlwjKzHUMv",
       "apple_music": "https://music.apple.com/us/album/symphony-for-wind-orchestra-montage-live/1737793406?i=1737794665&uo=4"
     },
     {
@@ -13995,19 +15245,19 @@
       "division": "1. divisjon",
       "band": "Os Musikkforening",
       "result_piece": "Armenian Dances, Part 1",
-      "recording_title": "Armenian Dances: 1: Part 1 - Live",
-      "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3hf3Ett70TjCSIiPduhTVE",
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-1-part-1-live/1737790756?i=1737792868&uo=4"
+      "recording_title": "Armenian Dances: I: Part 1 - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5c0aJGtTTJ3U4COGqVydCE",
+      "apple_music": "https://music.apple.com/us/album/armenian-dances-i-part-1-live/1737793406?i=1737794682&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Os Musikkforening",
       "result_piece": "Vesuvius",
-      "recording_title": "Vesuvius (Live)",
+      "recording_title": "Vesuvius - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4sodV8W3Vc0B6ZkXF0JWwz",
       "apple_music": "https://music.apple.com/us/album/vesuvius-live/1737793406?i=1737794678&uo=4"
     },
     {
@@ -14015,19 +15265,19 @@
       "division": "1. divisjon",
       "band": "Sandefjord Musikkorps",
       "result_piece": "An Gé Fhián",
-      "recording_title": "An Gé Fhiáin (The Wild Goose) - Live",
-      "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4QG5nJNli2Sl6nGT4hChSq",
-      "apple_music": "https://music.apple.com/us/album/an-g%C3%A9-fhi%C3%A1in-the-wild-goose-live/1737790756?i=1737792137&uo=4"
+      "recording_title": "An Gé fhiáin (The wild goose) - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4mTZoMkg8dGJSGVneW5zA9",
+      "apple_music": "https://music.apple.com/us/album/an-g%C3%A9-fhi%C3%A1in-the-wild-goose-live/1737793406?i=1737794668&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Sandefjord Musikkorps",
       "result_piece": "Aurora Awakes",
-      "recording_title": "Aurora Awakes (Live)",
+      "recording_title": "Aurora Awakes - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6rb0d2VuTB0e0MIgzCtIza",
       "apple_music": "https://music.apple.com/us/album/aurora-awakes-live/1737793406?i=1737794675&uo=4"
     },
     {
@@ -14035,9 +15285,9 @@
       "division": "1. divisjon",
       "band": "Sandvikens Ungdomskorps",
       "result_piece": "Gloriosa",
-      "recording_title": "Gloriosa (Live)",
+      "recording_title": "Gloriosa - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/3OnyUNRgbH6jNRv7mwRu0V",
       "apple_music": "https://music.apple.com/us/album/gloriosa-live/1737793406?i=1737793518&uo=4"
     },
     {
@@ -14046,18 +15296,18 @@
       "band": "Sarpsborg Janitsjarkorps",
       "result_piece": "Godspeed",
       "recording_title": "Godspeed - Live",
-      "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3cb8fTfc7mxpeIP04QY2P0",
-      "apple_music": "https://music.apple.com/us/album/godspeed-live/1737790756?i=1737791496&uo=4"
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4nuSB1geAJ6KUcKqTnwx1C",
+      "apple_music": "https://music.apple.com/us/album/godspeed-live/1737793406?i=1737794028&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Sarpsborg Janitsjarkorps",
       "result_piece": "Redline Tango",
-      "recording_title": "Redline Tango (Live)",
+      "recording_title": "Redline Tango - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/1SwbniWx1cDP7JAHY0cxHY",
       "apple_music": "https://music.apple.com/us/album/redline-tango-live/1737793406?i=1737793790&uo=4"
     },
     {
@@ -14065,19 +15315,29 @@
       "division": "1. divisjon",
       "band": "Sarpsborg Janitsjarkorps",
       "result_piece": "Sentimental Pebbles",
-      "recording_title": "Sentimental Pebbles (Live)",
+      "recording_title": "Sentimental Pebbles - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/1YooaqZM5mm5oxRNgceV1p",
       "apple_music": "https://music.apple.com/us/album/sentimental-pebbles-live/1737793406?i=1737793815&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "1. divisjon",
+      "band": "Skjold Nesttun Janitsjar",
+      "result_piece": "From Ancient Times",
+      "recording_title": "From Ancient Times - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5l9R85H5X0rbGF44osz2Sp",
+      "apple_music": "https://music.apple.com/us/album/from-ancient-times-live/1737793406?i=1737794666&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Stavanger Musikkorps av 1919",
       "result_piece": "Magnolia Star",
-      "recording_title": "Magnolia Star (Live)",
+      "recording_title": "Magnolia Star - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/2glLdGdDJewVlhor6Grjsq",
       "apple_music": "https://music.apple.com/us/album/magnolia-star-live/1737793406?i=1737794384&uo=4"
     },
     {
@@ -14085,40 +15345,110 @@
       "division": "1. divisjon",
       "band": "Stavanger Musikkorps av 1919",
       "result_piece": "The Frozen Cathedral",
-      "recording_title": "The Frozen Cathedral (Live)",
+      "recording_title": "The Frozen Cathedral - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6FwPy1YrnZsaUAaalhQUJu",
       "apple_music": "https://music.apple.com/us/album/the-frozen-cathedral-live/1737793406?i=1737794659&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Vestre Aker Musikkorps",
+      "result_piece": "Concert Overture for Symphonic Band",
+      "recording_title": "Concert ouverture - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2562Qeu192ag8Z3YkuosLM",
+      "apple_music": "https://music.apple.com/us/album/concert-ouverture-live/1737793406?i=1737795409&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "1. divisjon",
+      "band": "Vestre Aker Musikkorps",
       "result_piece": "Incantation and Dance",
-      "recording_title": "Incantation and Dance (Live)",
-      "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/incantation-and-dance-live/1737781717?i=1737782499&uo=4"
+      "recording_title": "Incantation and Dance - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4fjx4XDf2DbOyN65CA5TU4",
+      "apple_music": "https://music.apple.com/us/album/incantation-and-dance-live/1737793406?i=1737795416&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "1. divisjon",
+      "band": "Vestre Aker Musikkorps",
+      "result_piece": "Symphonic Metamorphosis of themes by Carl Maria von Weber, 4. sats March",
+      "recording_title": "Symfoniske metamorfoser: March - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/657NFQAchIIahnaIRjzSPS",
+      "apple_music": "https://music.apple.com/us/album/symfoniske-metamorfoser-march-live/1737793406?i=1737795422&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Ådalsbruk Musikkforening",
       "result_piece": "Symphony no. 1",
-      "recording_title": "Symphony no. 1: 1: Gilgamesh - Live",
-      "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3G9FGFnZvvkUEsETrA7O1y",
-      "apple_music": "https://music.apple.com/us/album/symphony-no-1-1-gilgamesh-live/1737790756?i=1737794409&uo=4"
+      "recording_title": "Asgard - Symphony No. 1 - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7t1M0NpCpnBmuXPbL8OKZz",
+      "apple_music": "https://music.apple.com/us/album/asgard-symphony-no-1-live/1737793406?i=1737794376&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Asker Musikkorps",
+      "result_piece": "Stratoscape",
+      "recording_title": "Stratoscape - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4JSuXRf46kVXmGhTZ6HGEj",
+      "apple_music": "https://music.apple.com/us/album/stratoscape-live/1738048279?i=1738049248&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Bispehaugen Ungdomskorps",
+      "result_piece": "Jungla, Poema ambientado en la Selva Africana",
+      "recording_title": "Jungla (Live)",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/jungla-live/1738048279?i=1738051382&uo=4"
     },
     {
       "year": 2024,
       "division": "2. divisjon",
       "band": "Bjølsen Ungdomskorps",
       "result_piece": "Symphony No IV: Bookmarks from Japan, 1., 2., 4., 5., og 6. sats",
-      "recording_title": "Bookmarks from Japan (Live)",
-      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/bookmarks-from-japan-live/1737793406?i=1737794037&uo=4"
+      "recording_title": "Symphoni No. 4 - Bookmarks from Japan: I, II, IV, V, VI - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/27b95ulRHL2qbqgLmlejH1",
+      "apple_music": "https://music.apple.com/us/album/symphoni-no-4-bookmarks-from-japan-i-ii-iv-v-vi-live/1738048279?i=1738050498&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Drammen Konsertorkester",
+      "result_piece": "Canto d'ommagio",
+      "recording_title": "Canto d´Ommagio - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0W8OVhBJfIRrMa5lzruXWA",
+      "apple_music": "https://music.apple.com/us/album/canto-dommagio-live/1738048279?i=1738048306&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Drammen Konsertorkester",
+      "result_piece": "Tam o'Shanter",
+      "recording_title": "Tam O´Shanter - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1vs1d7kY48sjqjBv2M5cku",
+      "apple_music": "https://music.apple.com/us/album/tam-oshanter-live/1738048279?i=1738048789&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Gjøvik Bykorps",
+      "result_piece": "Battle of Hearts",
+      "recording_title": "Battle of hearts - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1OxVwSMrE84sO7QF7Mx71G",
+      "apple_music": "https://music.apple.com/us/album/battle-of-hearts-live/1738048279?i=1738050510&uo=4"
     },
     {
       "year": 2024,
@@ -14126,9 +15456,59 @@
       "band": "Hov Musikkorps",
       "result_piece": "Arabesque",
       "recording_title": "Arabesque - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3BwDkNIZgX4etz2rzp1Yd4",
-      "apple_music": null
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7fw2CKB09lJfJU9EA6FWKS",
+      "apple_music": "https://music.apple.com/us/album/arabesque-live/1738048279?i=1738051216&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Hov Musikkorps",
+      "result_piece": "Third Suite for Band",
+      "recording_title": "Third Suite for Band - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3OEG6t7SeV4PLB8nXDDmCz",
+      "apple_music": "https://music.apple.com/us/album/third-suite-for-band-live/1738048279?i=1738051188&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Hovin Musikkorps",
+      "result_piece": "Las Aventuras del Principito",
+      "recording_title": "Las Aventuras del Principito - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1Y7YwLz1tNYptKlRLEbtCz",
+      "apple_music": "https://music.apple.com/us/album/las-aventuras-del-principito-live/1738048279?i=1738051645&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Lungegaardens Musikkorps",
+      "result_piece": "Seinsumarsdraum",
+      "recording_title": "Seinsumarsdraum - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4x2FUqMCBF83g57EoEtuID",
+      "apple_music": "https://music.apple.com/us/album/seinsumarsdraum-live/1738048279?i=1738049260&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Musikklaget Brage",
+      "result_piece": "Firework",
+      "recording_title": "Firework - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3GuxquDfn9Y4GEU6cr9n0R",
+      "apple_music": "https://music.apple.com/us/album/firework-live/1738048279?i=1738048809&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Musikklaget Brage",
+      "result_piece": "Milestones",
+      "recording_title": "Milestones - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1EvBvh6sVVW0WRt8z03k5l",
+      "apple_music": "https://music.apple.com/us/album/milestones-live/1738048279?i=1738049096&uo=4"
     },
     {
       "year": 2024,
@@ -14136,18 +15516,78 @@
       "band": "Ringsaker Janitjsar",
       "result_piece": "Carnival",
       "recording_title": "Carnival - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2IyTJIZ2Z7MpxXTVIjqRsI",
-      "apple_music": null
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1yx6eorkhNwTZpPtVoghVV",
+      "apple_music": "https://music.apple.com/us/album/carnival-live/1738048279?i=1738049498&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Ringsaker Janitjsar",
+      "result_piece": "Metroplex: Three Postcards from Manhattan",
+      "recording_title": "Metroplex - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1IoCFBHRoLzcmbQV9r6sR4",
+      "apple_music": "https://music.apple.com/us/album/metroplex-live/1738048279?i=1738049482&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Sinsen Konsertorkester",
+      "result_piece": "Colas Breugnon Overture",
+      "recording_title": "Colas Breugnon Overture - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/68Sp7FFGpFTD0MUHguPa5J",
+      "apple_music": "https://music.apple.com/us/album/colas-breugnon-overture-live/1738048279?i=1738050521&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Sinsen Konsertorkester",
+      "result_piece": "Masquerad",
+      "recording_title": "Masquerad - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2QG0AQL215ILluoluVcv7e",
+      "apple_music": "https://music.apple.com/us/album/masquerad-live/1738048279?i=1738050987&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Tromsø Orkesterforenings Janitsjarkorps",
+      "result_piece": "Nord",
+      "recording_title": "Nord - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6h6ebThqdlRqpoDtc087Q8",
+      "apple_music": "https://music.apple.com/us/album/nord-live/1738048279?i=1738050119&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Tønsberg Janitsjarkorps",
+      "result_piece": "Apocalyptic Dreams",
+      "recording_title": "Apocalyptic Dreams - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1eol6J3fSo4PSnqt86i136",
+      "apple_music": "https://music.apple.com/us/album/apocalyptic-dreams-live/1738048279?i=1738050107&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Vestsidens Musikkorps",
+      "result_piece": "Sidus",
+      "recording_title": "Sidus - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2pw6CAQW3Tujh8jLzIxhus",
+      "apple_music": "https://music.apple.com/us/album/sidus-live/1738048279?i=1738049899&uo=4"
     },
     {
       "year": 2024,
       "division": "3. divisjon",
       "band": "Aalesunds Ungdomsmusikkorps",
       "result_piece": "Unbroken",
-      "recording_title": "Unbroken (Live)",
+      "recording_title": "Unbroken - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/3xoMogZCi4m6R8OawL79rk",
       "apple_music": "https://music.apple.com/us/album/unbroken-live/1737781717?i=1737783138&uo=4"
     },
     {
@@ -14155,29 +15595,19 @@
       "division": "3. divisjon",
       "band": "Asker og Bærum Ungdomskorps",
       "result_piece": "Pompeii: The Ruins Know the Long and Magnificent History",
-      "recording_title": "Pompeii - the Ruins Know the Long and Magnificent History (Live)",
+      "recording_title": "Pompeii - the Ruins Know the Long and Magnificent History - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/0agHOM01K6BgwAU7JFI0eQ",
       "apple_music": "https://music.apple.com/us/album/pompeii-the-ruins-know-the-long-and/1737781717?i=1737782851&uo=4"
-    },
-    {
-      "year": 2024,
-      "division": "3. divisjon",
-      "band": "Fet Janitsjar",
-      "result_piece": "Triptych",
-      "recording_title": "Triptych - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/64MZCS504A3q6ieCrJXwQ1",
-      "apple_music": null
     },
     {
       "year": 2024,
       "division": "3. divisjon",
       "band": "Halsen Musikkforening",
       "result_piece": "Lake of the Moon",
-      "recording_title": "Lake of the Moon - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/6ebmU4oZogKQAn7SgZ3DtN",
+      "recording_title": "Lake of the moon - Live",
+      "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5GhjrSWUa6n2zEBwKAwpJ1",
       "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1737781717?i=1737782840&uo=4"
     },
     {
@@ -14185,9 +15615,9 @@
       "division": "3. divisjon",
       "band": "Hamar Musikkorps",
       "result_piece": "Saga Maligna",
-      "recording_title": "Saga Maligna (Live)",
+      "recording_title": "Saga Maligna - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/7h4PS5VpFDHNb1f20oSRO9",
       "apple_music": "https://music.apple.com/us/album/saga-maligna-live/1737781717?i=1737782479&uo=4"
     },
     {
@@ -14195,19 +15625,19 @@
       "division": "3. divisjon",
       "band": "Kongsberg Byorkester",
       "result_piece": "Give us this Day",
-      "recording_title": "Give us this day - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/6QBVJSty4wv3EFdvoRY5lj",
-      "apple_music": "https://music.apple.com/us/album/give-us-this-day-live/1737781717?i=1737782858&uo=4"
+      "recording_title": "Give Us This Day - Live",
+      "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0lVrwiCQ75Y1puC2DmNp9G",
+      "apple_music": "https://music.apple.com/us/album/give-us-this-day-live/1737781717?i=1737783183&uo=4"
     },
     {
       "year": 2024,
       "division": "3. divisjon",
       "band": "Moss og omegn Janitsjar",
       "result_piece": "Give us this Day",
-      "recording_title": "Give us this day - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/6QBVJSty4wv3EFdvoRY5lj",
+      "recording_title": "Give Us This Day - Live",
+      "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2z4fjC8O53KAr9apf90n9R",
       "apple_music": "https://music.apple.com/us/album/give-us-this-day-live/1737781717?i=1737782858&uo=4"
     },
     {
@@ -14215,9 +15645,9 @@
       "division": "3. divisjon",
       "band": "Nes Janitsjarkorps",
       "result_piece": "Headland Fantasy",
-      "recording_title": "Headland Fantasty (Live)",
+      "recording_title": "Headland Fantasty - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/7F4WTMVHdvInfGW4UldPFQ",
       "apple_music": "https://music.apple.com/us/album/headland-fantasty-live/1737781717?i=1737782505&uo=4"
     },
     {
@@ -14225,9 +15655,9 @@
       "division": "3. divisjon",
       "band": "Sagene Janitsjarkorps",
       "result_piece": "Symphonic Suite",
-      "recording_title": "Symphonic Suite (Live)",
+      "recording_title": "Symphonic Suite - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/1OG9fUHjUwnVVYnWE9n2Em",
       "apple_music": "https://music.apple.com/us/album/symphonic-suite-live/1737781717?i=1737781725&uo=4"
     },
     {
@@ -14235,19 +15665,9 @@
       "division": "3. divisjon",
       "band": "Sofienberg Musikkorps",
       "result_piece": "Lake of the Moon",
-      "recording_title": "Lake of the Moon - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/6ebmU4oZogKQAn7SgZ3DtN",
-      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1737781717?i=1737782840&uo=4"
-    },
-    {
-      "year": 2024,
-      "division": "3. divisjon",
-      "band": "Stabekk Janitsjarorkester",
-      "result_piece": "Triptych",
-      "recording_title": "Triptych - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/64MZCS504A3q6ieCrJXwQ1",
+      "recording_title": "Lake of the moon - Live",
+      "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5GhjrSWUa6n2zEBwKAwpJ1",
       "apple_music": null
     },
     {
@@ -14255,9 +15675,9 @@
       "division": "3. divisjon",
       "band": "Strindheim Janitsjar",
       "result_piece": "Incantation and Dance",
-      "recording_title": "Incantation and Dance (Live)",
+      "recording_title": "Incantation and Dance - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/51ofR6c4w5YROxherpMSt7",
       "apple_music": "https://music.apple.com/us/album/incantation-and-dance-live/1737781717?i=1737782499&uo=4"
     },
     {
@@ -14265,9 +15685,9 @@
       "division": "3. divisjon",
       "band": "Strindheim Janitsjar",
       "result_piece": "Xerxes",
-      "recording_title": "Xerxes (Live)",
+      "recording_title": "Xerxes - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6PWK8KJxZ9bQALQ2H2fZrw",
       "apple_music": "https://music.apple.com/us/album/xerxes-live/1737781717?i=1737782482&uo=4"
     },
     {
@@ -14275,9 +15695,9 @@
       "division": "3. divisjon",
       "band": "Sykkylven Janitsjarorkester",
       "result_piece": "Banja Luka",
-      "recording_title": "Banja Luka (Live)",
+      "recording_title": "Banja Luka - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/7dL30cRsPOkRUK8BLloMQF",
       "apple_music": "https://music.apple.com/us/album/banja-luka-live/1737781717?i=1737781721&uo=4"
     },
     {
@@ -14286,8 +15706,8 @@
       "band": "Åsane Musikklag",
       "result_piece": "Compostela",
       "recording_title": "Compostela - Live",
-      "album": "Nm Janitsjar 2024 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3QjnhABzVyiPXG1Lb7B5GA",
+      "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6EqUfpqKsA1dViyKdzXMql",
       "apple_music": "https://music.apple.com/us/album/compostela-live/1737781717?i=1737783179&uo=4"
     },
     {
@@ -14295,9 +15715,9 @@
       "division": "3. divisjon",
       "band": "Åsane Musikklag",
       "result_piece": "Ignition",
-      "recording_title": "Ignition (Live)",
+      "recording_title": "Ignition - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/49RbRZwzGh9gJ844OlN28a",
       "apple_music": "https://music.apple.com/us/album/ignition-live/1737781717?i=1737783170&uo=4"
     },
     {
@@ -14725,30 +16145,160 @@
       "division": "6. divisjon",
       "band": "Bjørgvin Blåseensemble",
       "result_piece": "Astronauten-Marsch",
-      "recording_title": "Astronauten-Marsch - Live",
-      "album": "Nm Janitsjar 2024 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/0rZBjkcRW58pHBsvjFb4GQ",
-      "apple_music": "https://music.apple.com/us/album/astronauten-marsch-live/1739590005?i=1739591409&uo=4"
+      "recording_title": "Astronauten - Marsch - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4lQZKRM0InJYsDzBOvBbNe",
+      "apple_music": "https://music.apple.com/us/album/astronauten-marsch-live/1737785171?i=1737786068&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Bjørgvin Blåseensemble",
+      "result_piece": "Norwegian Dance",
+      "recording_title": "Norwegian Dance - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5pdTvODma9OpUNe3f7Zkm4",
+      "apple_music": "https://music.apple.com/us/album/norwegian-dance-live/1737785171?i=1737785999&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Bjørgvin Blåseensemble",
+      "result_piece": "Slava!",
+      "recording_title": "Slava! - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3En5CMGWcyTeUxT6qFtkJL",
+      "apple_music": "https://music.apple.com/us/album/slava-live/1737785171?i=1737786590&uo=4"
     },
     {
       "year": 2024,
       "division": "6. divisjon",
       "band": "Drøbak Musikkorps",
       "result_piece": "Lake of the Moon",
-      "recording_title": "Lake of the Moon - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/6ebmU4oZogKQAn7SgZ3DtN",
-      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1737781717?i=1737782840&uo=4"
+      "recording_title": "Lake of the moon - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7d68Z2ffhPxWVdLKZJ86pk",
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1737785171?i=1737786744&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Follebu og Vestre Gausdal Musikkforening",
+      "result_piece": "Golden Peak",
+      "recording_title": "Golden Peak - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1E1d8Q3tuZuzp3CwCk2Wxu",
+      "apple_music": "https://music.apple.com/us/album/golden-peak-live/1737785171?i=1737789720&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Hegra Hornmusikklag",
+      "result_piece": "First Suite in Eb for Military Band, 1. sats, Chaconne",
+      "recording_title": "First Suite in E flat: I: 1. movement - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2Ya2bdM5FUuneyJF52lUGl",
+      "apple_music": "https://music.apple.com/us/album/first-suite-in-e-flat-i-1-movement-live/1737785171?i=1737787224&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Hegra Hornmusikklag",
+      "result_piece": "Yosemite Autumn",
+      "recording_title": "Yosemite Autumn - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3n8Rno3QbTbBXCj94hQtjB",
+      "apple_music": "https://music.apple.com/us/album/yosemite-autumn-live/1737785171?i=1737787587&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Hommelvik Musikkorps",
+      "result_piece": "Prevision",
+      "recording_title": "Prevision - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1F6VRk4u6wu8Vc5Ba9ocER",
+      "apple_music": "https://music.apple.com/us/album/prevision-live/1737785171?i=1737787922&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Jevnaker Ungdomskorps",
+      "result_piece": "Freedom Defended",
+      "recording_title": "Freedom Defended - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1w6xxMiE4QyyZrA5hfpU1t",
+      "apple_music": "https://music.apple.com/us/album/freedom-defended-live/1737785171?i=1737788446&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Jevnaker Ungdomskorps",
+      "result_piece": "Minnen från Holmen",
+      "recording_title": "Minnen från holmen - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5IX7vnkGeYUSrpdErbPN3q",
+      "apple_music": "https://music.apple.com/us/album/minnen-fr%C3%A5n-holmen-live/1737785171?i=1737788432&uo=4"
     },
     {
       "year": 2024,
       "division": "6. divisjon",
       "band": "Kila Musikkforening",
       "result_piece": "Candide Overture",
-      "recording_title": "Concert ouverture (Live)",
-      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/concert-ouverture-live/1737793406?i=1737795409&uo=4"
+      "recording_title": "Overture to candide - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/58qfP3JqgCfqZgJ0FoIsvH",
+      "apple_music": "https://music.apple.com/us/album/overture-to-candide-live/1737785171?i=1737789381&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Kila Musikkforening",
+      "result_piece": "Symphony no. 1, The Lord of the Rings, \"Gandalf\"",
+      "recording_title": "Symphony no. 1 - The Lord of the Rings: I: Gandalf - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7nC2TiSPzA7VrOneGqXMgN",
+      "apple_music": "https://music.apple.com/us/album/symphony-no-1-the-lord-of-the-rings-i-gandalf-live/1737785171?i=1737789399&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Klæbu Musikkorps",
+      "result_piece": "Variations for Band",
+      "recording_title": "Variations for band - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4sxVfKptBQfCy1ADgot1gX",
+      "apple_music": "https://music.apple.com/us/album/variations-for-band-live/1737785171?i=1737785526&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Musikkorpset TEMPO",
+      "result_piece": "The Air Race",
+      "recording_title": "The Air Race - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2zpE2P3tPTejv491UgkC0x",
+      "apple_music": "https://music.apple.com/us/album/the-air-race-live/1737785171?i=1737788761&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Musikkorpset TEMPO",
+      "result_piece": "Veslemøys Sang",
+      "recording_title": "Veslemøys sang - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/13gC9FnfzHT33ThGFWqmXf",
+      "apple_music": "https://music.apple.com/us/album/veslem%C3%B8ys-sang-live/1737785171?i=1737788756&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Namsos Musikkorps",
+      "result_piece": "On the Way to 100 Years",
+      "recording_title": "On the way to 100 years - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7EuWs3N9sFxMCAzwFlrYKH",
+      "apple_music": "https://music.apple.com/us/album/on-the-way-to-100-years-live/1737785171?i=1737787929&uo=4"
     },
     {
       "year": 2024,
@@ -14756,19 +16306,59 @@
       "band": "Namsos Musikkorps",
       "result_piece": "Underlige Aftenlufte",
       "recording_title": "Underlige Aftenlufte - Live",
-      "album": "Nm Janitsjar 2024 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/45ruKEMDqzIEG4jw7tlFwa",
-      "apple_music": "https://music.apple.com/us/album/underlige-aftenlufte-live/1739590005?i=1739591395&uo=4"
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6kXrI0SYABvav5oOscLLDU",
+      "apple_music": "https://music.apple.com/us/album/underlige-aftenlufte-live/1737785171?i=1737788418&uo=4"
     },
     {
       "year": 2024,
       "division": "6. divisjon",
       "band": "Nordre Aker Janitsjar",
       "result_piece": "A Springtime Celebration",
-      "recording_title": "Time for celebration - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7A8S4lTwUCTIKxKQmh0ncb",
-      "apple_music": "https://music.apple.com/us/album/a-symphonic-celebration-live/1737782962?i=1737784272&uo=4"
+      "recording_title": "A Springtime Celebration - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3pb4MbmMPx4b6LnOEAfjSG",
+      "apple_music": "https://music.apple.com/us/album/a-springtime-celebration-live/1737785171?i=1737785512&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Nordre Aker Janitsjar",
+      "result_piece": "New York: 1927",
+      "recording_title": "New York: 1927 - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6oDxJFAIREfertFYB511vT",
+      "apple_music": "https://music.apple.com/us/album/new-york-1927-live/1737785171?i=1737785522&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Skatval Hornmusikklag",
+      "result_piece": "Symphony no. 1, The Lord of the Rings, \"Hobbits\"",
+      "recording_title": "Symphony no. 1 - The Lord of the Rings: V: Hobbits - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4FCqG4a2uGJg6rneSL9QIL",
+      "apple_music": "https://music.apple.com/us/album/symphony-no-1-the-lord-of-the-rings-v-hobbits-live/1737785171?i=1737787219&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Trøgstad Janitsjar",
+      "result_piece": "Cassiopeia",
+      "recording_title": "Cassiopeia - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/42HxfAnpzYfG8a6npmBcfq",
+      "apple_music": "https://music.apple.com/us/album/cassiopeia-live/1737785171?i=1737789051&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Trøgstad Janitsjar",
+      "result_piece": "Hoch Heidecksburg, op. 10",
+      "recording_title": "Hoch Heidecksburg Op. 10 - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1A4vizVeSqECExyi8BbXpX",
+      "apple_music": "https://music.apple.com/us/album/hoch-heidecksburg-op-10-live/1737785171?i=1737789069&uo=4"
     },
     {
       "year": 2024,
@@ -14776,18 +16366,28 @@
       "band": "Vålerenga Janitsjarkorps",
       "result_piece": "Eldorado",
       "recording_title": "Eldorado - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1eH2aTLHNxKTTvwOS3rBMo",
-      "apple_music": "https://music.apple.com/us/album/eldorado-live/1737782962?i=1737783810&uo=4"
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0H8WwGoBTWbNi8cHj3VJ6O",
+      "apple_music": "https://music.apple.com/us/album/eldorado-live/1737785171?i=1737787597&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Åndalsnes Musikkforening",
+      "result_piece": "Music for a Solemnity",
+      "recording_title": "Music for a Solemnity - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7yxd01MgymOuXt9GQUcCLH",
+      "apple_music": "https://music.apple.com/us/album/music-for-a-solemnity-live/1737785171?i=1737785175&uo=4"
     },
     {
       "year": 2024,
       "division": "7. divisjon",
       "band": "Egersund Musikkorps",
       "result_piece": "A Symphonic Celebration",
-      "recording_title": "A Symphonic Celebration (Live)",
+      "recording_title": "A Symphonic Celebration - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4GPWwxH10s8VQqXwsafBgQ",
       "apple_music": "https://music.apple.com/us/album/a-symphonic-celebration-live/1737782962?i=1737784272&uo=4"
     },
     {
@@ -14795,9 +16395,9 @@
       "division": "7. divisjon",
       "band": "Egersund Musikkorps",
       "result_piece": "Mount Everest",
-      "recording_title": "Mount Everest (Live)",
+      "recording_title": "Mount Everest - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4PnIXGUO0LL7CHmTkL1qoU",
       "apple_music": "https://music.apple.com/us/album/mount-everest-live/1737782962?i=1737784637&uo=4"
     },
     {
@@ -14805,9 +16405,9 @@
       "division": "7. divisjon",
       "band": "Hennummusikken",
       "result_piece": "Corpo Hennum festivo",
-      "recording_title": "Corpo Hennum festivo (Live)",
+      "recording_title": "Corpo Hennum festivo - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/7DQwirtwuFtrJIIPqRJr5q",
       "apple_music": "https://music.apple.com/us/album/corpo-hennum-festivo-live/1737782962?i=1737783818&uo=4"
     },
     {
@@ -14816,8 +16416,8 @@
       "band": "Hennummusikken",
       "result_piece": "Eldorado",
       "recording_title": "Eldorado - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1eH2aTLHNxKTTvwOS3rBMo",
+      "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4z7aohArxA3F88cE2YuURN",
       "apple_music": "https://music.apple.com/us/album/eldorado-live/1737782962?i=1737783810&uo=4"
     },
     {
@@ -14825,9 +16425,9 @@
       "division": "7. divisjon",
       "band": "Lier og Drammen Ungdomskorps",
       "result_piece": "Concerto d’Amore",
-      "recording_title": "Concerto D'Amore (Live)",
+      "recording_title": "Concerto D´Amore - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6oXA3stJUQRr9p8hTaxal5",
       "apple_music": "https://music.apple.com/us/album/concerto-damore-live/1737782962?i=1737784944&uo=4"
     },
     {
@@ -14835,9 +16435,9 @@
       "division": "7. divisjon",
       "band": "Lier og Drammen Ungdomskorps",
       "result_piece": "Highlights from the Greatest Showman",
-      "recording_title": "Highlights from the Greatest Showman (Live)",
+      "recording_title": "Highlights from the Greatest Showman - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4f8K7xFrYaxU77ehB7yclY",
       "apple_music": "https://music.apple.com/us/album/highlights-from-the-greatest-showman-live/1737782962?i=1737784663&uo=4"
     },
     {
@@ -14845,19 +16445,19 @@
       "division": "7. divisjon",
       "band": "Musikklaget Kornetten",
       "result_piece": "Overture to a new Age",
-      "recording_title": "Overture Op. 2 - Live",
-      "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2ykMprkin0cJUglvfLjWWW",
-      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age-live/1737782962?i=1737784270&uo=4"
+      "recording_title": "Overture to a new age - Live",
+      "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0vb7hyOQwHThPDgUIEihJb",
+      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age-live/1737782962?i=1737784639&uo=4"
     },
     {
       "year": 2024,
       "division": "7. divisjon",
       "band": "Musikklaget Laat",
       "result_piece": "Another Way Home",
-      "recording_title": "Another Way Home (Live)",
+      "recording_title": "Another Way Home - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/2Z28U53oE0EPJDxTu9ihIP",
       "apple_music": "https://music.apple.com/us/album/another-way-home-live/1737782962?i=1737783531&uo=4"
     },
     {
@@ -14865,9 +16465,9 @@
       "division": "7. divisjon",
       "band": "Musikklaget Laat",
       "result_piece": "Fanfare for an Occasion",
-      "recording_title": "Fanfare for an Occasion (Live)",
+      "recording_title": "Fanfare for an Occasion - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/3xI46yL8QYHPocctAU4iic",
       "apple_music": "https://music.apple.com/us/album/fanfare-for-an-occasion-live/1737782962?i=1737783387&uo=4"
     },
     {
@@ -14875,9 +16475,9 @@
       "division": "7. divisjon",
       "band": "Musikklaget Laat",
       "result_piece": "They Solemnly Served",
-      "recording_title": "They Solemnly Served (Live)",
+      "recording_title": "They Solemnly Served - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6WQLuwEAb2iNanmxJ01i96",
       "apple_music": "https://music.apple.com/us/album/they-solemnly-served-live/1737782962?i=1737783527&uo=4"
     },
     {
@@ -14885,19 +16485,19 @@
       "division": "7. divisjon",
       "band": "Nørvøy Ungdomskorps",
       "result_piece": "Compostela",
-      "recording_title": "Compostela - Live",
-      "album": "Nm Janitsjar 2024 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3QjnhABzVyiPXG1Lb7B5GA",
-      "apple_music": "https://music.apple.com/us/album/compostela-live/1737781717?i=1737783179&uo=4"
+      "recording_title": "Compostela - The Way of St James - Live",
+      "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4c1eXZgRDIx8vkj8GaxIFr",
+      "apple_music": "https://music.apple.com/us/album/compostela-the-way-of-st-james-live/1737782962?i=1737783826&uo=4"
     },
     {
       "year": 2024,
       "division": "7. divisjon",
       "band": "Søndre Nittedal Veterankorps",
       "result_piece": "Merlin",
-      "recording_title": "Merlin (Live)",
+      "recording_title": "Merlin - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4FizF6updrmN56NnXr5tcL",
       "apple_music": "https://music.apple.com/us/album/merlin-live/1737782962?i=1737784075&uo=4"
     },
     {
@@ -14905,9 +16505,9 @@
       "division": "7. divisjon",
       "band": "Søndre Nittedal Veterankorps",
       "result_piece": "Novena",
-      "recording_title": "Novena (Live)",
+      "recording_title": "Novena - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6I2Zgip0CX1cUtGI1cpzZH",
       "apple_music": "https://music.apple.com/us/album/novena-live/1737782962?i=1737784253&uo=4"
     },
     {
@@ -14915,9 +16515,9 @@
       "division": "7. divisjon",
       "band": "TUBE",
       "result_piece": "Christian Daae på setra",
-      "recording_title": "Christian Daae på setra (Live)",
+      "recording_title": "Christian Daae på setra - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/5FB6prrddY6EpBXO1X0MAc",
       "apple_music": "https://music.apple.com/us/album/christian-daae-p%C3%A5-setra-live/1737782962?i=1737784953&uo=4"
     },
     {
@@ -14925,9 +16525,9 @@
       "division": "7. divisjon",
       "band": "Tretten Musikkforening",
       "result_piece": "Ammerland",
-      "recording_title": "Ammerland (Live)",
+      "recording_title": "Ammerland - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4j5R3FEOYnWbDntGeHSJRJ",
       "apple_music": "https://music.apple.com/us/album/ammerland-live/1737782962?i=1737783764&uo=4"
     },
     {
@@ -14935,9 +16535,9 @@
       "division": "7. divisjon",
       "band": "Tretten Musikkforening",
       "result_piece": "The Last Letter from Murdoch",
-      "recording_title": "The last letter from Murdoch (Live)",
+      "recording_title": "The last letter from Murdoch - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/5OsHRdpRU6BBFDTN4dIFdS",
       "apple_music": "https://music.apple.com/us/album/the-last-letter-from-murdoch-live/1737782962?i=1737783801&uo=4"
     },
     {
@@ -14945,9 +16545,9 @@
       "division": "7. divisjon",
       "band": "Valldal Hornmusikklag",
       "result_piece": "The Flood",
-      "recording_title": "The Flood (Live)",
+      "recording_title": "The Flood - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/2kBeF2fwfGvxKJ16975CjM",
       "apple_music": "https://music.apple.com/us/album/the-flood-live/1737782962?i=1737784262&uo=4"
     },
     {
@@ -14955,9 +16555,9 @@
       "division": "7. divisjon",
       "band": "Vang Musikkforening",
       "result_piece": "Overture to a new Age",
-      "recording_title": "Overture Op. 2 - Live",
-      "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2ykMprkin0cJUglvfLjWWW",
+      "recording_title": "Overture to a new Age - Live",
+      "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6HOE94A6AzRUejLb6tj52B",
       "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age-live/1737782962?i=1737784270&uo=4"
     },
     {
@@ -14983,6 +16583,56 @@
     {
       "year": 2024,
       "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "Vårofferet",
+      "recording_title": "The Rite of Spring (Live)",
+      "album": "NM Janitsjar 2024 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5BChs0DHLaQzUUsuzPKSWt?si=2577c646aaa54419",
+      "apple_music": "https://music.apple.com/no/album/the-rite-of-spring-live/1737790756?i=1737793781"
+    },
+    {
+      "year": 2024,
+      "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "Vårofferet",
+      "recording_title": "The Rite of Spring (Live)",
+      "album": "NM Janitsjar 2024 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5BChs0DHLaQzUUsuzPKSWt?si=2577c646aaa54419",
+      "apple_music": "https://music.apple.com/no/album/the-rite-of-spring-live/1737790756?i=1737793781"
+    },
+    {
+      "year": 2024,
+      "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "Vårofferet",
+      "recording_title": "The Rite of Spring (Live)",
+      "album": "NM Janitsjar 2024 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5BChs0DHLaQzUUsuzPKSWt?si=2577c646aaa54419",
+      "apple_music": "https://music.apple.com/no/album/the-rite-of-spring-live/1737790756?i=1737793781"
+    },
+    {
+      "year": 2024,
+      "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "Vårofferet",
+      "recording_title": "The Rite of Spring (Live)",
+      "album": "NM Janitsjar 2024 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5BChs0DHLaQzUUsuzPKSWt?si=2577c646aaa54419",
+      "apple_music": "https://music.apple.com/no/album/the-rite-of-spring-live/1737790756?i=1737793781"
+    },
+    {
+      "year": 2024,
+      "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "Vårofferet",
+      "recording_title": "The Rite of Spring (Live)",
+      "album": "NM Janitsjar 2024 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5BChs0DHLaQzUUsuzPKSWt?si=2577c646aaa54419",
+      "apple_music": "https://music.apple.com/no/album/the-rite-of-spring-live/1737790756?i=1737793781"
+    },
+    {
+      "year": 2024,
+      "division": "Elite",
       "band": "Dragefjellets Musikkorps Bergen",
       "result_piece": "Armenian Dances, Part 1",
       "recording_title": "Armenian Dances: 1: Part 1 - Live",
@@ -14998,7 +16648,7 @@
       "recording_title": "Dirty Dancing for Large Wind Ensemble - Live",
       "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/5rmLmXF7kRvHZ8UcNMBieY",
-      "apple_music": "https://music.apple.com/us/album/dirty-dancing-live/1737790756?i=1737793270&uo=4"
+      "apple_music": "https://music.apple.com/us/album/dirty-dancing-for-large-wind-ensemble-live/1737790756?i=1737792885&uo=4"
     },
     {
       "year": 2024,
@@ -15098,16 +16748,26 @@
       "recording_title": "Svit ur Bergakungen - Live",
       "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/0oRHa7wnxeXkBUMP7B92E3",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/svit-ur-bergakungen-live/1737790756?i=1737794255&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "Elite",
+      "band": "Opus 82",
+      "result_piece": "Ouverture, op. 2",
+      "recording_title": "Overture Op. 2 - Live",
+      "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2ykMprkin0cJUglvfLjWWW",
+      "apple_music": "https://music.apple.com/us/album/overture-op-2-live/1737790756?i=1737794061&uo=4"
     },
     {
       "year": 2024,
       "division": "Elite",
       "band": "Strusshamn Musikkforening",
       "result_piece": "Dirty Dancing",
-      "recording_title": "Dirty Dancing for Large Wind Ensemble - Live",
+      "recording_title": "Dirty Dancing - Live",
       "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/5rmLmXF7kRvHZ8UcNMBieY",
+      "spotify": "https://open.spotify.com/track/4jkuiveDeUgoYQGH99ugzZ",
       "apple_music": "https://music.apple.com/us/album/dirty-dancing-live/1737790756?i=1737793270&uo=4"
     },
     {
@@ -15174,6 +16834,16 @@
       "year": 2025,
       "division": "1. divisjon",
       "band": "Kolbotn Konsertorkester",
+      "result_piece": "Fest-Overture, Op. 26",
+      "recording_title": "Fest- Ouvertyre - Live",
+      "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5FHxVI38qGsIZunbl0qpze",
+      "apple_music": "https://music.apple.com/us/album/fest-ouvertyre-live/1808651334?i=1808651349&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "1. divisjon",
+      "band": "Kolbotn Konsertorkester",
       "result_piece": "Variations for Wind Band",
       "recording_title": "Variations for wind band - Live",
       "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
@@ -15223,6 +16893,16 @@
     {
       "year": 2025,
       "division": "1. divisjon",
+      "band": "Os Musikkforening",
+      "result_piece": "Symphony No IV: Bookmarks from Japan",
+      "recording_title": "Bookmarks from Japan - Live",
+      "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2e52QUo2h4tLUd913RWZjl",
+      "apple_music": "https://music.apple.com/us/album/bookmarks-from-japan-live/1808651334?i=1808651749&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "1. divisjon",
       "band": "Sandefjord Musikkorps",
       "result_piece": "Fanfare and Choral",
       "recording_title": "Fanfare og koral - Live",
@@ -15237,8 +16917,8 @@
       "result_piece": "Traveler",
       "recording_title": "Traveler - Live",
       "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/0QfcFB9QDSWxosHBh1uii5",
-      "apple_music": "https://music.apple.com/us/album/traveler-live/1808651334?i=1808651551&uo=4"
+      "spotify": "https://open.spotify.com/track/02T37TSPlavZhvk1ZZjuGm",
+      "apple_music": "https://music.apple.com/us/album/traveler-live/1808651334?i=1808652419&uo=4"
     },
     {
       "year": 2025,
@@ -15285,10 +16965,10 @@
       "division": "1. divisjon",
       "band": "Strusshamn Musikkforening",
       "result_piece": "Firefly",
-      "recording_title": "Firefly - Live",
+      "recording_title": "Firefly - for Sophia and Nyla - Live",
       "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/0mfTZELhCC4HwLQxphxy8z",
-      "apple_music": "https://music.apple.com/us/album/firefly-live/1808651334?i=1808651722&uo=4"
+      "spotify": "https://open.spotify.com/track/78WJYkpnAp8lsoFpYwczWv",
+      "apple_music": "https://music.apple.com/us/album/firefly-for-sophia-and-nyla-live/1808651334?i=1808651985&uo=4"
     },
     {
       "year": 2025,
@@ -15297,8 +16977,8 @@
       "result_piece": "Fraternity",
       "recording_title": "Fraternity - Live",
       "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3pUL29AT4Tr9qpYcD8myqJ",
-      "apple_music": "https://music.apple.com/us/album/fraternity-live/1808651334?i=1808651565&uo=4"
+      "spotify": "https://open.spotify.com/track/13SFoQ2fIYLs0JAly8kyvk",
+      "apple_music": "https://music.apple.com/us/album/fraternity-live/1808651334?i=1808652143&uo=4"
     },
     {
       "year": 2025,
@@ -15365,9 +17045,9 @@
       "division": "2. divisjon",
       "band": "Aalesunds Ungdomsmusikkorps",
       "result_piece": "Ride",
-      "recording_title": "El jardin de las hespérides - Live",
-      "album": "Nm Janitsjar 2025 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4wn8dQ9PbdUZeCPboEceYk",
+      "recording_title": "Ride - Live",
+      "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6YX5Gwcm4JRSBwqhlSVg3M",
       "apple_music": "https://music.apple.com/us/album/ride-live/1808655359?i=1808656163&uo=4"
     },
     {
@@ -15385,10 +17065,10 @@
       "division": "2. divisjon",
       "band": "Asker og Bærum Ungdomskorps",
       "result_piece": "Symphony No IV: Bookmarks from Japan, 1., 2., 4., 5., og 6. sats",
-      "recording_title": "Bookmarks from Japan (Live)",
-      "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/bookmarks-from-japan-live/1808651334?i=1808651749&uo=4"
+      "recording_title": "Bookmarks from Japan: I, II, IV, V, VI - Live",
+      "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/25vbBJh31SIbg19Yna8DHO",
+      "apple_music": "https://music.apple.com/us/album/bookmarks-from-japan-i-ii-iv-v-vi-live/1808655359?i=1808656323&uo=4"
     },
     {
       "year": 2025,
@@ -15437,8 +17117,8 @@
       "result_piece": "Sidus",
       "recording_title": "Sidus - Live",
       "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1ylq9fzl24JiuhppyqmpFD",
-      "apple_music": "https://music.apple.com/us/album/sidus-live/1808655359?i=1808656587&uo=4"
+      "spotify": "https://open.spotify.com/track/3RohBUwZjYxsR08GBsvpzn",
+      "apple_music": "https://music.apple.com/us/album/sidus-live/1808655359?i=1808656599&uo=4"
     },
     {
       "year": 2025,
@@ -15468,7 +17148,7 @@
       "recording_title": "Triptych - Live",
       "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0YHbC8DApKnrUdpLl21F5H",
-      "apple_music": "https://music.apple.com/us/album/triptych-live/1808652240?i=1808652614&uo=4"
+      "apple_music": "https://music.apple.com/us/album/triptych-live/1808655359?i=1808655623&uo=4"
     },
     {
       "year": 2025,
@@ -15488,7 +17168,7 @@
       "recording_title": "Lake of the Moon - Live",
       "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/75UKX8SlCp1y6Sivzw7upM",
-      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1808652240?i=1808652606&uo=4"
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1808655359?i=1808655642&uo=4"
     },
     {
       "year": 2025,
@@ -15498,7 +17178,7 @@
       "recording_title": "Karneval i Paris - Live",
       "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5OYkpvCaL4MtF2iuIRfcGS",
-      "apple_music": "https://music.apple.com/us/album/carnival-live/1808651177?i=1808651546&uo=4"
+      "apple_music": null
     },
     {
       "year": 2025,
@@ -15508,7 +17188,17 @@
       "recording_title": "I fred bland träden bo - Live",
       "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/3g9RNxXsUsbsHnYKD6bYcO",
-      "apple_music": "https://music.apple.com/us/album/i-fred-bland-tr%C3%A4den-bo-live/1808655359?i=1808655975&uo=4"
+      "apple_music": null
+    },
+    {
+      "year": 2025,
+      "division": "2. divisjon",
+      "band": "Sinsen Konsertorkester",
+      "result_piece": "Ballet Suite nr 5, The Bolt (1. Overture, 6. Dance of the Colonial Bondswoman, 8. General Dance and Apotheosis)",
+      "recording_title": "Ballesuite No. 5: I: Overture, VI: Dance of the Bondswoman, VIII: Generel Dance and Apotheosis - Live",
+      "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0olazGy4zHPMw4PZdrWOs6",
+      "apple_music": "https://music.apple.com/us/album/dance-of-the-tumblers-live/1808655359?i=1808656609&uo=4"
     },
     {
       "year": 2025,
@@ -15579,6 +17269,16 @@
       "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5jogQYFph3opXezpuZoxhk",
       "apple_music": "https://music.apple.com/us/album/lux-futura-live/1808655359?i=1808655620&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "3. divisjon",
+      "band": "Bodø Harmonimusikk",
+      "result_piece": "Childrens March",
+      "recording_title": "Children´s March \"Over the hills and far away\" - Live",
+      "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2q0vsZNhTOGO3TePmP8xL2",
+      "apple_music": "https://music.apple.com/us/album/childrens-march-over-the-hills-and-far-away-live/1808651177?i=1808651970&uo=4"
     },
     {
       "year": 2025,
@@ -15673,6 +17373,16 @@
     {
       "year": 2025,
       "division": "3. divisjon",
+      "band": "Lørenskog Blåseensemble",
+      "result_piece": "Symphony No. 9 \"The New World\", 4. sats Finale",
+      "recording_title": "The new world symphony: Finale - Live",
+      "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6OvrrHw8QuVnWLxHPQ2Sjh",
+      "apple_music": "https://music.apple.com/us/album/the-new-world-symphony-finale-live/1808651177?i=1808652155&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "3. divisjon",
       "band": "Nes Janitsjarkorps",
       "result_piece": "The White Deer",
       "recording_title": "The White Deer - Live",
@@ -15714,6 +17424,16 @@
       "year": 2025,
       "division": "3. divisjon",
       "band": "Skedsmo Janitsjarorkester",
+      "result_piece": "Ignition",
+      "recording_title": "Ignition - Live",
+      "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0LQalUanHsnuSOY8qSDdhv",
+      "apple_music": "https://music.apple.com/us/album/ignition-live/1808651177?i=1808651354&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "3. divisjon",
+      "band": "Skedsmo Janitsjarorkester",
       "result_piece": "With Heart and Voice",
       "recording_title": "With heart and voice - Live",
       "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
@@ -15733,12 +17453,22 @@
     {
       "year": 2025,
       "division": "3. divisjon",
+      "band": "Strindheim Janitsjar",
+      "result_piece": "Symphony No IV: Bookmarks from Japan, 1., 2., 4. og 6. sats",
+      "recording_title": "Bookmarks from Japan: I, II, IV, VI - Live",
+      "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5vA9he5sBJ3ooBpBS7VsAn",
+      "apple_music": "https://music.apple.com/us/album/bookmarks-from-japan-i-ii-iv-vi-live/1808651177?i=1808652150&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "3. divisjon",
       "band": "Åsane Musikklag",
       "result_piece": "Banja Luka",
       "recording_title": "Banja Luka - Live",
       "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2mntFI7JMZF8ZEetmJrs5F",
-      "apple_music": "https://music.apple.com/us/album/banja-luka-live/1808651177?i=1808651742&uo=4"
+      "spotify": "https://open.spotify.com/track/69R3K6UB1hzc763zPwsTIf",
+      "apple_music": "https://music.apple.com/us/album/banja-luka-live/1808651177?i=1808651960&uo=4"
     },
     {
       "year": 2025,
@@ -15747,8 +17477,8 @@
       "result_piece": "Compostela",
       "recording_title": "Compostela - Live",
       "album": "Nm Janitsjar 2025 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3F0HgsFNWLUrkRhw96llmy",
-      "apple_music": "https://music.apple.com/us/album/compostela-live/1808652240?i=1808652597&uo=4"
+      "spotify": "https://open.spotify.com/track/1OQLmnNM3gFJjMKUBQTSV3",
+      "apple_music": "https://music.apple.com/us/album/compostela-live/1808652240?i=1808652991&uo=4"
     },
     {
       "year": 2025,
@@ -15897,8 +17627,8 @@
       "result_piece": "Lake of the Moon",
       "recording_title": "Lake of the Moon - Live",
       "album": "Nm Janitsjar 2025 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1pfiaQlQ4yaKs9k23CJg3u",
-      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1808652240?i=1808652606&uo=4"
+      "spotify": "https://open.spotify.com/track/09zCdnmYOfZJzDufyI3Z6K",
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1808652240?i=1808653004&uo=4"
     },
     {
       "year": 2025,
@@ -15907,8 +17637,8 @@
       "result_piece": "Third Suite for Band (Scenes de Ballet)",
       "recording_title": "Third Suite for Band - Live",
       "album": "Nm Janitsjar 2025 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/5xKd9KQJxNDVYQiXNhT4II",
-      "apple_music": "https://music.apple.com/us/album/third-suite-for-band-live/1808652240?i=1808652246&uo=4"
+      "spotify": "https://open.spotify.com/track/6mYuk9odW9OwlK8nbyAWyS",
+      "apple_music": "https://music.apple.com/us/album/third-suite-for-band-live/1808652240?i=1808652594&uo=4"
     },
     {
       "year": 2025,
@@ -15973,12 +17703,92 @@
     {
       "year": 2025,
       "division": "5. divisjon",
+      "band": "Byåsen Musikkorps",
+      "result_piece": "Black Gold",
+      "recording_title": "Black Gold - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4OEKi8ZIv0X5N00vSS7RDA",
+      "apple_music": "https://music.apple.com/us/album/black-gold-live/1808651247?i=1808651268&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Bømlo Janitsjar",
+      "result_piece": "Black Gold",
+      "recording_title": "Black Gold - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1cLlCTidjEiCmiiXY51DwY",
+      "apple_music": "https://music.apple.com/us/album/black-gold-live/1808651247?i=1808651259&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
       "band": "Eina Musikkforening",
       "result_piece": "Banja Luka",
       "recording_title": "Banja Luka - Live",
-      "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2mntFI7JMZF8ZEetmJrs5F",
-      "apple_music": "https://music.apple.com/us/album/banja-luka-live/1808651177?i=1808651742&uo=4"
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3NMREnKenLAGw0m3Q4RXUu",
+      "apple_music": "https://music.apple.com/us/album/banja-luka-live/1808651247?i=1808651263&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Hommelvik Musikkorps",
+      "result_piece": "Excalibur",
+      "recording_title": "Excalibur - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0UVkTzMxsWAenWqSNWn8zA",
+      "apple_music": "https://music.apple.com/us/album/excalibur-live/1808651247?i=1808652002&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Hønefoss Ungdomskorps",
+      "result_piece": "Floating Flags",
+      "recording_title": "Floating Flags - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5HLeAHBlxycIR4yI9OvCnu",
+      "apple_music": "https://music.apple.com/us/album/floating-flags-live/1808651247?i=1808651442&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Klæbu Musikkorps",
+      "result_piece": "Prelude to a Celebration",
+      "recording_title": "Prelude to a Celebration - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5q3r5jjBCL0ReNoNhRdw8B",
+      "apple_music": "https://music.apple.com/us/album/prelude-to-a-celebration-live/1808651247?i=1808651434&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Klæbu Musikkorps",
+      "result_piece": "Saint and the City",
+      "recording_title": "The Saint and The City - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1IrFeT2A3rCU2KtB9dfSYq",
+      "apple_music": "https://music.apple.com/us/album/the-saint-and-the-city-live/1808651247?i=1808651425&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Lier og Drammen Ungdomskorps",
+      "result_piece": "Bunch O'Bones",
+      "recording_title": "Bunch O´Bones - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2cwe9aIuvG0MrOdIHkpE4B",
+      "apple_music": "https://music.apple.com/us/album/bunch-obones-live/1808651247?i=1808651444&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Lier og Drammen Ungdomskorps",
+      "result_piece": "Noah’s Ark",
+      "recording_title": "Noah´s Ark - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0ms74W1KiVaSVqaGRbaihL",
+      "apple_music": "https://music.apple.com/us/album/noahs-ark-live/1808651247?i=1808651448&uo=4"
     },
     {
       "year": 2025,
@@ -15986,39 +17796,59 @@
       "band": "Modum Janitsjar",
       "result_piece": "Second Suite for Band",
       "recording_title": "Second Suite for Band - Live",
-      "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1fGuenp0yurbnF3wXrsVlu",
-      "apple_music": "https://music.apple.com/us/album/second-suite-for-band-live/1808651177?i=1808651976&uo=4"
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/03yDDatCyHayqHAKuGuA3g",
+      "apple_music": "https://music.apple.com/us/album/second-suite-for-band-live/1808651247?i=1808651804&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Musikklaget Kornetten",
+      "result_piece": "Utopia",
+      "recording_title": "Utopia - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2Zfd7wT21dPi7LZ7Ojl2IS",
+      "apple_music": "https://music.apple.com/us/album/utopia-live/1808651247?i=1808651666&uo=4"
     },
     {
       "year": 2025,
       "division": "5. divisjon",
       "band": "Nidarvoll Ungdomskorps",
       "result_piece": "Angels in the Architecture",
-      "recording_title": "Angels in The Architecture - Live",
-      "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2zuuyNOst4ysA1ShQI2M1z",
-      "apple_music": "https://music.apple.com/us/album/angels-in-the-architecture-live/1808651334?i=1808651732&uo=4"
+      "recording_title": "Angels in the Architecture - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/49GHF6O7P561dhL0Juu1lY",
+      "apple_music": "https://music.apple.com/us/album/angels-in-the-architecture-live/1808651247?i=1808652075&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Rælingen Musikklag",
+      "result_piece": "Crown Him With Many Crowns",
+      "recording_title": "Crown him with many crowns - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2h0eXF3khCOTMJA8oVkNR8",
+      "apple_music": "https://music.apple.com/us/album/crown-him-with-many-crowns-live/1808651247?i=1808652007&uo=4"
     },
     {
       "year": 2025,
       "division": "5. divisjon",
       "band": "Rælingen Musikklag",
       "result_piece": "Of Castles and Legends",
-      "recording_title": "Tales and Legends - Live",
-      "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/6XPbbNTTdabI2vltPISc3h",
-      "apple_music": "https://music.apple.com/us/album/tales-and-legends-live/1808651334?i=1808651340&uo=4"
+      "recording_title": "Of Castles and Legends - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7p1KBboP7HjtTP29U3qJgN",
+      "apple_music": "https://music.apple.com/us/album/of-castles-and-legends-live/1808651247?i=1808652062&uo=4"
     },
     {
       "year": 2025,
       "division": "5. divisjon",
       "band": "Strinda Ungdomskorps",
       "result_piece": "Festsodd: Divertimento for Korps",
-      "recording_title": "Divertimento (Live)",
-      "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/divertimento-live/1808655359?i=1808655631&uo=4"
+      "recording_title": "Festsodd: Divertimento for korps - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5dcoP3pcxRkItOmWxt8blj",
+      "apple_music": "https://music.apple.com/us/album/festsodd-divertimento-for-korps-live/1808651247?i=1808652069&uo=4"
     },
     {
       "year": 2025,
@@ -16026,9 +17856,39 @@
       "band": "Tolga-Os Janitsjar",
       "result_piece": "Lake of the Moon",
       "recording_title": "Lake of the Moon - Live",
-      "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/75UKX8SlCp1y6Sivzw7upM",
-      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1808652240?i=1808652606&uo=4"
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3n3BSTgzsBtFr0isLNWkNE",
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1808651247?i=1808651680&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Vålerenga Janitsjarkorps",
+      "result_piece": "Hispanola",
+      "recording_title": "Hispaniola - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7HV25d9P456bPQuMwTel0W",
+      "apple_music": "https://music.apple.com/us/album/hispaniola-live/1808651247?i=1808651787&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Ås og Vestby Musikkorps",
+      "result_piece": "Hispanola",
+      "recording_title": "Hispaniola - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1D0yltMEn0xKMLsYjsuFQM",
+      "apple_music": "https://music.apple.com/us/album/hispaniola-live/1808651247?i=1808651993&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Østensjø Janitsjar",
+      "result_piece": "Hispanola",
+      "recording_title": "Hispaniola - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/243TDcPWBO4PVFnn9fKHTo",
+      "apple_music": "https://music.apple.com/us/album/hispaniola-live/1808651247?i=1808651781&uo=4"
     },
     {
       "year": 2025,
@@ -16075,10 +17935,10 @@
       "division": "6. divisjon",
       "band": "Jevnaker Ungdomskorps",
       "result_piece": "Overture to a new Age",
-      "recording_title": "Overture to a New Age - Live",
+      "recording_title": "Overture to a new age - Live",
       "album": "Nm Janitsjar 2025 - 6. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1EhEuBKcglrqDAUxBjzp0f",
-      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age-live/1808661166?i=1808661930&uo=4"
+      "spotify": "https://open.spotify.com/track/1nCFiiJ3DkkBFriLDxxSVw",
+      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age-live/1808661166?i=1808662674&uo=4"
     },
     {
       "year": 2025,
@@ -16133,6 +17993,16 @@
     {
       "year": 2025,
       "division": "6. divisjon",
+      "band": "Skatval Hornmusikklag",
+      "result_piece": "Golden Peak",
+      "recording_title": "Golden Peak - Live",
+      "album": "Nm Janitsjar 2025 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0xbfGBXxcQIL6xIaHq7cOc",
+      "apple_music": "https://music.apple.com/us/album/golden-peak-live/1808661166?i=1808661940&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "6. divisjon",
       "band": "Søndre Nittedal Veterankorps",
       "result_piece": "Exultation",
       "recording_title": "Exultation - Live",
@@ -16159,6 +18029,16 @@
       "album": "Nm Janitsjar 2025 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/3ka66uHpJQSokg4QSmKCEM",
       "apple_music": "https://music.apple.com/us/album/christian-daae-p%C3%A5-maaenen-live/1808661166?i=1808661921&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "6. divisjon",
+      "band": "Tretten Musikkforening",
+      "result_piece": "Compostela",
+      "recording_title": "Compostella, The way of St James - Live",
+      "album": "Nm Janitsjar 2025 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3baxtuMdLlqxFDxOpiwm0U",
+      "apple_music": "https://music.apple.com/us/album/compostella-the-way-of-st-james-live/1808661166?i=1808661416&uo=4"
     },
     {
       "year": 2025,
@@ -16199,6 +18079,16 @@
       "album": "Nm Janitsjar 2025 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0B3QFSsavAAKaBf3Hqf8b1",
       "apple_music": "https://music.apple.com/us/album/eldorado-live/1808661166?i=1808662160&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "6. divisjon",
+      "band": "Åndalsnes Musikkforening",
+      "result_piece": "Ross Roy, Overture for Band",
+      "recording_title": "The Roy - Live",
+      "album": "Nm Janitsjar 2025 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5EMNSRa0oGJIGGVk0Wc3lf",
+      "apple_music": null
     },
     {
       "year": 2025,
@@ -16259,6 +18149,16 @@
       "album": "Nm Janitsjar 2025 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/31eLk3hZgXzQEVTINUqEYK",
       "apple_music": "https://music.apple.com/us/album/rheinische-kirmest%C3%A4nze-live/1808647720?i=1808648140&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "7. divisjon",
+      "band": "Flisbyen Blåseensemble",
+      "result_piece": "Pilatus: Mountain of Dragons",
+      "recording_title": "Pilatus: Mountain of dragons - Live",
+      "album": "Nm Janitsjar 2025 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6rCQlhku4LLzGE3qwEPx35",
+      "apple_music": "https://music.apple.com/us/album/pilatus-mountain-of-dragons-live/1808647720?i=1808647997&uo=4"
     },
     {
       "year": 2025,
@@ -16332,6 +18232,16 @@
     },
     {
       "year": 2025,
+      "division": "7. divisjon",
+      "band": "Øystese Musikklag",
+      "result_piece": "Concerto d’Amore",
+      "recording_title": "Concerto D´amore - Live",
+      "album": "Nm Janitsjar 2025 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1jAZkrzKrA2506s0r979AH",
+      "apple_music": "https://music.apple.com/us/album/concerto-damore-live/1808647720?i=1808647972&uo=4"
+    },
+    {
+      "year": 2025,
       "division": "Elite",
       "band": "Alvøens Musikkforening",
       "result_piece": "El Jardin de Las Herspérides",
@@ -16339,6 +18249,16 @@
       "album": "Nm Janitsjar 2025 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/4wn8dQ9PbdUZeCPboEceYk",
       "apple_music": "https://music.apple.com/us/album/el-jardin-de-las-hesp%C3%A9rides-live/1808651022?i=1808651445&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "Elite",
+      "band": "Byneset Musikkorps",
+      "result_piece": "From Ancient Times",
+      "recording_title": "From Anciet Times - Live",
+      "album": "Nm Janitsjar 2025 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5nfIGe1p0gbJEw7q89RIpO",
+      "apple_music": "https://music.apple.com/us/album/from-anciet-times-live/1808651022?i=1808651258&uo=4"
     },
     {
       "year": 2025,
@@ -16368,7 +18288,7 @@
       "recording_title": "Svit ur Bergakungen - Live",
       "album": "Nm Janitsjar 2025 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/2lnvhFpO0ItxeSMtAJzIP1",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/svit-ur-bergakungen-live/1808651022?i=1808651786&uo=4"
     },
     {
       "year": 2025,
@@ -16409,6 +18329,16 @@
       "album": "Nm Janitsjar 2025 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/30C6rBhwy7acyeQbCLnzPc",
       "apple_music": "https://music.apple.com/us/album/the-merry-king-live/1808651022?i=1808651664&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "Elite",
+      "band": "Lørenskog Musikkorps",
+      "result_piece": "Symphony no. 1, ‘Gilgamesh’",
+      "recording_title": "Symphony No. 1: Gligamesh - Live",
+      "album": "Nm Janitsjar 2025 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0DiiSxEbs2GqsivWhfuM9D",
+      "apple_music": "https://music.apple.com/us/album/symphony-no-1-gligamesh-live/1808651022?i=1808651262&uo=4"
     },
     {
       "year": 2025,

--- a/apps/band-positions/public/data/piece_streaming_links.json
+++ b/apps/band-positions/public/data/piece_streaming_links.json
@@ -12365,10 +12365,10 @@
       "division": "1. divisjon",
       "band": "Asker Musikkorps",
       "result_piece": "Tales and Legends, 1. og 2. sats",
-      "recording_title": "Tales and Legends - Live",
+      "recording_title": "Tales & Legends: I. - II. - Live",
       "album": "NM Janitsjar 2023 - 1. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2uQgdFMHZiv4Nk2Z2d6TNm",
-      "apple_music": "https://music.apple.com/us/album/tales-and-legends-live/1681187798?i=1681188408&uo=4"
+      "spotify": "https://open.spotify.com/track/0kOpIjVtFQwoIE6HA9hWWC",
+      "apple_music": "https://music.apple.com/us/album/tales-legends-i-ii-live/1681187798?i=1681188183&uo=4"
     },
     {
       "year": 2023,
@@ -12438,7 +12438,7 @@
       "recording_title": "Asgard Symphony no. 1 - Live",
       "album": "NM Janitsjar 2023 - 1. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/4HbB09NZdp8naP7eMXPbQu",
-      "apple_music": "https://music.apple.com/us/album/symphony-no-4-live/1680515141?i=1680515326&uo=4"
+      "apple_music": "https://music.apple.com/us/album/asgard-symphony-no-1-live/1681187798?i=1681188315&uo=4"
     },
     {
       "year": 2023,
@@ -12515,10 +12515,10 @@
       "division": "1. divisjon",
       "band": "Sande Musikkorps",
       "result_piece": "Norsk Rapsodi nr. 1",
-      "recording_title": "Norsk Rapsodi Nr. 1 - Live",
-      "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4vml3HvFIVRGaJ9jnXznSZ",
-      "apple_music": "https://music.apple.com/us/album/norsk-rapsodi-nr-1-live/1680515141?i=1680515799&uo=4"
+      "recording_title": "Rhapsodie Norvegienne Nr. 1 - Live",
+      "album": "NM Janitsjar 2023 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6L41L1Y1tHNLj8v0JF6LqR",
+      "apple_music": "https://music.apple.com/us/album/rhapsodie-norvegienne-nr-1-live/1681187798?i=1681188297&uo=4"
     },
     {
       "year": 2023,
@@ -12534,11 +12534,21 @@
       "year": 2023,
       "division": "1. divisjon",
       "band": "Skjold Nesttun Janitsjar",
+      "result_piece": "An Gé Fhián",
+      "recording_title": "The Wild Goose - Live",
+      "album": "NM Janitsjar 2023 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3TFKu5SAVFujNmrK7Ub4ev",
+      "apple_music": null
+    },
+    {
+      "year": 2023,
+      "division": "1. divisjon",
+      "band": "Skjold Nesttun Janitsjar",
       "result_piece": "Fanfare and Choral",
       "recording_title": "Fanfare og Koral - Live",
       "album": "NM Janitsjar 2023 - 1. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0vYaZRLCXj2GOMs5QuKdnO",
-      "apple_music": "https://music.apple.com/us/album/fanfare-and-choral-live/1680806260?i=1680806967&uo=4"
+      "apple_music": "https://music.apple.com/us/album/fanfare-og-koral-live/1681187798?i=1681188026&uo=4"
     },
     {
       "year": 2023,
@@ -12563,32 +12573,242 @@
     {
       "year": 2023,
       "division": "2. divisjon",
+      "band": "Bispehaugen Ungdomskorps",
+      "result_piece": "Saga Candida",
+      "recording_title": "Saga Candida - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2AoiP2XKRdL3UL3PvkOzVq",
+      "apple_music": "https://music.apple.com/us/album/saga-candida-live/1681188276?i=1681189820&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Bjølsen Ungdomskorps",
+      "result_piece": "Ride",
+      "recording_title": "Ride - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3iGoWgZsMx0VroN6igjqBk",
+      "apple_music": "https://music.apple.com/us/album/ride-live/1681188276?i=1681188701&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
       "band": "Bjølsen Ungdomskorps",
       "result_piece": "Spiritual Planet",
-      "recording_title": "Scintallant (Live)",
-      "album": "NM Janitsjar 2023 - 1. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/scintallant-live/1681187798?i=1681188018&uo=4"
+      "recording_title": "Spiritual Planet - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1BbwT6NAmulL2waL3qyVsP",
+      "apple_music": "https://music.apple.com/us/album/spiritual-planet-live/1681188276?i=1681188957&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Drammen Konsertorkester",
+      "result_piece": "High Wire",
+      "recording_title": "High Wire - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7BO5NCtTnxuf79s74CD2rb",
+      "apple_music": "https://music.apple.com/us/album/high-wire-live/1681188276?i=1681188974&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Drammen Konsertorkester",
+      "result_piece": "Poéme du Feu",
+      "recording_title": "Poeme du Feu - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7zpfyGoMELALM12vqLVTSj",
+      "apple_music": "https://music.apple.com/us/album/poeme-du-feu-live/1681188276?i=1681188964&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Gjøvik Bykorps",
+      "result_piece": "La Procession du Roico",
+      "recording_title": "La Procession du Roico - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4nkdXid3u2KkKU4Q2ypgHI",
+      "apple_music": "https://music.apple.com/us/album/la-procession-du-roico-live/1681188276?i=1681189593&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Gjøvik Bykorps",
+      "result_piece": "Wer ist Elise",
+      "recording_title": "Wer ist Elise - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4NYtJ9Ea8MaUQrJs4Utihu",
+      "apple_music": "https://music.apple.com/us/album/wer-ist-elise-live/1681188276?i=1681189597&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Hov Musikkorps",
+      "result_piece": "Danzón no. 2",
+      "recording_title": "Danzón Nr. 2 - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0uDqKiea524jeLN7Ik1wwk",
+      "apple_music": "https://music.apple.com/us/album/danz%C3%B3n-nr-2-live/1681188276?i=1681188450&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Hov Musikkorps",
+      "result_piece": "Hjalar-Ljod",
+      "recording_title": "Hjalar-Ljord - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3v46TnyIIlko1NdXxGoMin",
+      "apple_music": "https://music.apple.com/us/album/hjalar-ljord-live/1681188276?i=1681188445&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Hovin Musikkorps",
+      "result_piece": "Armenian Dances, Part 1",
+      "recording_title": "Armenian Dances: Part 1 - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7BxRk4p7DlN52Bj1Gp3FnG",
+      "apple_music": "https://music.apple.com/us/album/armenian-dances-part-1-live/1681188276?i=1681188681&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Hovin Musikkorps",
+      "result_piece": "Perseus",
+      "recording_title": "Perseus - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2VJKjGNwxPEnuYtv9HpAW3",
+      "apple_music": "https://music.apple.com/us/album/perseus-live/1681188276?i=1681188690&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Lungegaardens Musikkorps",
+      "result_piece": "Villfar",
+      "recording_title": "Villfar - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1ff2L7AkWtU7ViY3t4I4Iz",
+      "apple_music": "https://music.apple.com/us/album/villfar-live/1681188276?i=1681189131&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Musikklaget Brage",
+      "result_piece": "Fragile Oasis",
+      "recording_title": "Fragile Oasis - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1CW6ESDt3o3k6rGrj4Rnm5",
+      "apple_music": "https://music.apple.com/us/album/fragile-oasis-live/1681188276?i=1681188458&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Musikklaget Brage",
+      "result_piece": "Start-Up",
+      "recording_title": "Start-Up - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7uQXs1usJhacWVFZCbAMkj",
+      "apple_music": "https://music.apple.com/us/album/start-up-live/1681188276?i=1681188454&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Sandvikens Ungdomskorps",
+      "result_piece": "Carnival",
+      "recording_title": "Carnival - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2BBSUh0G8HpYW5IanzcOfs",
+      "apple_music": "https://music.apple.com/us/album/carnival-live/1681188276?i=1681189401&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Sandvikens Ungdomskorps",
+      "result_piece": "Ride",
+      "recording_title": "Ride - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6mxHW3x2qsNT83S3lNSJso",
+      "apple_music": "https://music.apple.com/us/album/ride-live/1681188276?i=1681189416&uo=4"
     },
     {
       "year": 2023,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Symphony no. 3 “Slavyanskaya”",
-      "recording_title": "Symphony No. 4 - Live",
-      "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3gMUdgZ3U7gsghdsYkL05f",
-      "apple_music": null
+      "recording_title": "Symphony No. 3 \"Slavyanskaya\" - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2ckXiXLmSBLbMQ6h6z8uke",
+      "apple_music": "https://music.apple.com/us/album/symphony-no-3-slavyanskaya-live/1681188276?i=1681189153&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Strindheim Janitsjar",
+      "result_piece": "Jungla, Poema ambientado en la Selva Africana",
+      "recording_title": "Jungla, Poema ambientado en la Selva Africana - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/033r0JxAQctQN8Rm9bos7D",
+      "apple_music": "https://music.apple.com/us/album/jungla-poema-ambientado-en-la-selva-africana-live/1681188276?i=1681189588&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Sykkylven Janitsjarorkester",
+      "result_piece": "Sidus",
+      "recording_title": "Sidus - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4T8PpLy2aDaXuiPAc7VMfv",
+      "apple_music": "https://music.apple.com/us/album/sidus-live/1681188276?i=1681189150&uo=4"
     },
     {
       "year": 2023,
       "division": "2. divisjon",
       "band": "Tromsø Orkesterforenings Janitsjarkorps",
       "result_piece": "Fleodrodum",
-      "recording_title": "Fleodrodum (Live)",
-      "album": "Nm Janitsjar 2023 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/fleodrodum-live/1680508500?i=1680509351&uo=4"
+      "recording_title": "Fleododrum - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0l5qEzGuWnxIjTJD74JdOi",
+      "apple_music": "https://music.apple.com/us/album/fleododrum-live/1681188276?i=1681189919&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Tønsberg Janitsjarkorps",
+      "result_piece": "Audivi Media Nocte",
+      "recording_title": "Audivi Media Nocte - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2NoO3EpASV3CM3dK1sEEKM",
+      "apple_music": "https://music.apple.com/us/album/audivi-media-nocte-live/1681188276?i=1681188464&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Vestre Aker Musikkorps",
+      "result_piece": "Stabsarabesk",
+      "recording_title": "Stabsarabesk - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1xQJLGS6YuHQqwapIoXgzw",
+      "apple_music": "https://music.apple.com/us/album/stabsarabesk-live/1681188276?i=1681189143&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Vestre Aker Musikkorps",
+      "result_piece": "Sørgemarsj til minne om Richard Nordraak, Op. 117",
+      "recording_title": "Sørgemarsj (til minne om Rikard Nordraak) - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0ubIbae6of49LqWzHBLU4r",
+      "apple_music": "https://music.apple.com/us/album/s%C3%B8rgemarsj-til-minne-om-rikard-nordraak-live/1681188276?i=1681189137&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Ådalsbruk Musikkforening",
+      "result_piece": "Divertimento",
+      "recording_title": "Divertimento - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2h3CkzGJhHpw9QbkgtfrwB",
+      "apple_music": "https://music.apple.com/us/album/divertimento-live/1681188276?i=1681189581&uo=4"
     },
     {
       "year": 2023,
@@ -12617,8 +12837,8 @@
       "result_piece": "Machu Picchu - City in the sky - the mystery of the hidden sun Temple",
       "recording_title": "Machu Picchu - City in the Sky The Mystery of the Hidden Sun Temple - Live",
       "album": "Nm Janitsjar 2023 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7FXBbPXsO0QOInWk5MBWUw",
-      "apple_music": "https://music.apple.com/us/album/machu-picchu-city-in-the-sky-the-mystery-of/1680806260?i=1680806453&uo=4"
+      "spotify": "https://open.spotify.com/track/4RgP8rqrNtchFmz5XteQ35",
+      "apple_music": "https://music.apple.com/us/album/machu-picchu-city-in-the-sky-the-mystery-of/1680806260?i=1680806782&uo=4"
     },
     {
       "year": 2023,
@@ -12647,17 +12867,17 @@
       "result_piece": "Machu Picchu - City in the sky - the mystery of the hidden sun Temple",
       "recording_title": "Machu Picchu - City in the Sky The Mystery of the Hidden Sun Temple - Live",
       "album": "Nm Janitsjar 2023 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7FXBbPXsO0QOInWk5MBWUw",
-      "apple_music": "https://music.apple.com/us/album/machu-picchu-city-in-the-sky-the-mystery-of/1680806260?i=1680806453&uo=4"
+      "spotify": "https://open.spotify.com/track/6TKgUAtg6APqMOIbKJ4qNO",
+      "apple_music": "https://music.apple.com/us/album/machu-picchu-city-in-the-sky-the-mystery-of/1680806260?i=1680807212&uo=4"
     },
     {
       "year": 2023,
       "division": "3. divisjon",
       "band": "Halsen Musikkforening",
       "result_piece": "Armenian Dances, Part 1",
-      "recording_title": "Armenian Dances: Part 1 - Live",
-      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7BxRk4p7DlN52Bj1Gp3FnG",
+      "recording_title": "Armenian Dances: I. Part 1 - Live",
+      "album": "Nm Janitsjar 2023 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1LcF4lgPX9tOopJovxSaCu",
       "apple_music": "https://music.apple.com/us/album/armenian-dances-i-part-1-live/1680806260?i=1680807221&uo=4"
     },
     {
@@ -12729,6 +12949,16 @@
       "album": "Nm Janitsjar 2023 - 3. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/3VRZt3xJAUO7rz6nLmkpwI",
       "apple_music": "https://music.apple.com/us/album/made-in-bergen-live/1680806260?i=1680806471&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "3. divisjon",
+      "band": "Sagene Janitsjarkorps",
+      "result_piece": "Childrens March",
+      "recording_title": "Children´s March: \"over the hill and far away\" - Live",
+      "album": "Nm Janitsjar 2023 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4d3VCtIMgrNVG441Hvwx6K",
+      "apple_music": "https://music.apple.com/us/album/childrens-march-over-the-hill-and-far-away-live/1680806260?i=1680806776&uo=4"
     },
     {
       "year": 2023,
@@ -12814,6 +13044,16 @@
       "year": 2023,
       "division": "4. divisjon",
       "band": "Eidsvoll Janitsjarkorps",
+      "result_piece": "Cavetowns \"Cappadocia\"",
+      "recording_title": "Cavetaowns \"Cappadocia\" - Live",
+      "album": "Nm Janitsjar 2023 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2DOrAIOprA591J4urolx71",
+      "apple_music": "https://music.apple.com/us/album/cavetaowns-cappadocia-live/1680508500?i=1680509906&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "4. divisjon",
+      "band": "Eidsvoll Janitsjarkorps",
       "result_piece": "Fanfare",
       "recording_title": "Fanfare - The Benefication from Sky and Mother Earth - Live",
       "album": "Nm Janitsjar 2023 - 4. divisjon (Live)",
@@ -12826,8 +13066,8 @@
       "band": "Fana Musikklag",
       "result_piece": "Hispanola",
       "recording_title": "Hispaniola (Concert Band) - Live",
-      "album": "Nm Janitsjar 2023 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/5rMGwvOSSMrgYvVAAeqy2X",
+      "album": "Nm Janitsjar 2023 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3AYEnTw1TlOoS1jndPhOka",
       "apple_music": "https://music.apple.com/us/album/hispaniola-concert-band-live/1680508500?i=1680509818&uo=4"
     },
     {
@@ -12836,8 +13076,8 @@
       "band": "Hamar Musikkorps",
       "result_piece": "The Story of Anne Frank",
       "recording_title": "The Story of Anne Frank - Live",
-      "album": "Nm Janitsjar 2023 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2wDsJSFsgxKaCHlPdiopqL",
+      "album": "Nm Janitsjar 2023 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2GB5sdOELxeKTidV1d4iBo",
       "apple_music": "https://music.apple.com/us/album/the-story-of-anne-frank-live/1680508500?i=1680509332&uo=4"
     },
     {
@@ -12876,9 +13116,9 @@
       "band": "Oppegård Janitsjar",
       "result_piece": "Lake of the Moon",
       "recording_title": "Lake of The Moon (Wind Band) - Live",
-      "album": "Nm Janitsjar 2023 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7LfVzXuuciaOZwPs08Pl3S",
-      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-wind-band-live/1680508500?i=1680509827&uo=4"
+      "album": "Nm Janitsjar 2023 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/46lxeIEGy6IW7ak3vzhaXv",
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-wind-band-live/1680508500?i=1680509924&uo=4"
     },
     {
       "year": 2023,
@@ -12896,8 +13136,8 @@
       "band": "Skedsmo Janitsjarorkester",
       "result_piece": "Lake of the Moon",
       "recording_title": "Lake of The Moon (Wind Band) - Live",
-      "album": "Nm Janitsjar 2023 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7LfVzXuuciaOZwPs08Pl3S",
+      "album": "Nm Janitsjar 2023 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4vLZLIg3xMnWmwmv0NG4gP",
       "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-wind-band-live/1680508500?i=1680509827&uo=4"
     },
     {
@@ -13088,7 +13328,7 @@
       "recording_title": "Eldorado - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5U6YW7F7qhaPrAhLReBNrX",
-      "apple_music": "https://music.apple.com/us/album/eldorado-live/1681182666?i=1681183341&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13098,17 +13338,17 @@
       "recording_title": "The Adventures of Baron Munchausen - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1trqi4dV0CoQV2lD2KXNdL",
-      "apple_music": "https://music.apple.com/us/album/the-adventures-of-baron-munchausen-live/1681182666?i=1681183083&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
       "division": "6. divisjon",
       "band": "Follebu og Vestre Gausdal Musikkforening",
       "result_piece": "Ross Roy, Overture for Band",
-      "recording_title": "Ross Roy (Live)",
+      "recording_title": "Ross Roy - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/ross-roy-live/1681182666?i=1681184275&uo=4"
+      "spotify": "https://open.spotify.com/track/73oWqEFJJCivVgIziQmF93",
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13118,7 +13358,7 @@
       "recording_title": "Where Eagles Soar - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/16F3ZY4nKu6VjRjKUVBSCb",
-      "apple_music": "https://music.apple.com/us/album/where-eagles-soar-live/1681182666?i=1681184281&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13128,7 +13368,7 @@
       "recording_title": "First Suite for Military Band, No. 1: Chaconne - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6xasp3p4B7RAOU8sCytGor",
-      "apple_music": "https://music.apple.com/us/album/first-suite-for-military-band-no-1-chaconne-live/1681182666?i=1681182675&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13138,7 +13378,7 @@
       "recording_title": "Les Parapluies de Cherboourg - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/3BjsUrG2yLUJFloDqzo9hv",
-      "apple_music": "https://music.apple.com/us/album/les-parapluies-de-cherboourg-live/1681182666?i=1681183079&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13148,7 +13388,7 @@
       "recording_title": "Samtidig, ein annan stad enn no - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/4jMcDsmMv6UbsBWZ8m6Sbr",
-      "apple_music": "https://music.apple.com/us/album/samtidig-ein-annan-stad-enn-no-live/1681182666?i=1681184043&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13158,7 +13398,7 @@
       "recording_title": "Edenstrand - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1G6UgyIu0JYbLTcmXXMRud",
-      "apple_music": "https://music.apple.com/us/album/edenstrand-live/1681182666?i=1681184032&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13168,7 +13408,7 @@
       "recording_title": "Victory: Samtidig, ein annan stad enn no - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6HnDPIg0I7EPzNOKqP6GcR",
-      "apple_music": "https://music.apple.com/us/album/victory-samtidig-ein-annan-stad-enn-no-live/1681182666?i=1681184034&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13178,7 +13418,7 @@
       "recording_title": "Music for a Solemnity - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1p4psz5bB4voVUUTESFjNt",
-      "apple_music": "https://music.apple.com/us/album/music-for-a-solemnity-live/1681182666?i=1681183789&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13188,17 +13428,17 @@
       "recording_title": "A Malvern Suite - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5VNh1uQps8zh1GK6rSIb2e",
-      "apple_music": "https://music.apple.com/us/album/a-malvern-suite-live/1681182666?i=1681183796&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
       "division": "6. divisjon",
       "band": "Moss og omegn Janitsjar",
       "result_piece": "Armenian Dances, Part 1",
-      "recording_title": "Armenian Dances: I. Part 1 - Live",
-      "album": "Nm Janitsjar 2023 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1LcF4lgPX9tOopJovxSaCu",
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1681182666?i=1681183631&uo=4"
+      "recording_title": "Armenian Dances - Live",
+      "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0CGoCMusnQtO7wutKcrqVv",
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13208,7 +13448,7 @@
       "recording_title": "Dawn of a New Day - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/7h0n8AiiEuvu7vAnimK4K0",
-      "apple_music": "https://music.apple.com/us/album/dawn-of-a-new-day-live/1681182666?i=1681183793&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13218,7 +13458,7 @@
       "recording_title": "Persis - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6b9uw3Ihnu4oCcE0ymku4p",
-      "apple_music": "https://music.apple.com/us/album/persis-live/1681182666?i=1681183794&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13228,7 +13468,7 @@
       "recording_title": "Prelude, Siciliano and Rondo - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2qe6oZ9txFtcCvhhs5ptlq",
-      "apple_music": "https://music.apple.com/us/album/prelude-siciliano-and-rondo-live/1681182666?i=1681183338&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13238,7 +13478,7 @@
       "recording_title": "Street Tango - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/4u5aWaD4uskfwRufAntttX",
-      "apple_music": "https://music.apple.com/us/album/street-tango-live/1681182666?i=1681183090&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13248,7 +13488,7 @@
       "recording_title": "D-day - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5sEJceG9bpjewVr6mMAdQY",
-      "apple_music": "https://music.apple.com/us/album/d-day-live/1681182666?i=1681183087&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13258,7 +13498,7 @@
       "recording_title": "Eine Kleine Yiddishe Ragmusik - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0PxAJ3IPmpc2CaNRuIo9Oo",
-      "apple_music": "https://music.apple.com/us/album/eine-kleine-yiddishe-ragmusik-live/1681182666?i=1681184269&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13266,9 +13506,9 @@
       "band": "Strinda Ungdomskorps",
       "result_piece": "Tales and Myths of Gothia",
       "recording_title": "Tales and Myths of Gothia - Live",
-      "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4UMoMVQ0swi2ZNLEfSuVS2",
-      "apple_music": "https://music.apple.com/us/album/tales-and-myths-of-gothia-live/1681182666?i=1681183362&uo=4"
+      "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2xUA2neXltPO9gpaP9of58",
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13277,8 +13517,8 @@
       "result_piece": "Street Tango",
       "recording_title": "Street Tango - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4u5aWaD4uskfwRufAntttX",
-      "apple_music": "https://music.apple.com/us/album/street-tango-live/1681182666?i=1681183090&uo=4"
+      "spotify": "https://open.spotify.com/track/2jcFxGDnGD1vir8uA6vWhF",
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13286,9 +13526,9 @@
       "band": "Vålerenga Janitsjarkorps",
       "result_piece": "Tales and Myths of Gothia",
       "recording_title": "Tales and Myths of Gothia - Live",
-      "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4UMoMVQ0swi2ZNLEfSuVS2",
-      "apple_music": "https://music.apple.com/us/album/tales-and-myths-of-gothia-live/1681182666?i=1681183362&uo=4"
+      "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/63i0Bn9xdEgS4F7h5fcmBQ",
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13298,7 +13538,7 @@
       "recording_title": "Pilatus: Mountain of Dragons - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6TiDAJWvAeGB4qWeMVdKCD",
-      "apple_music": "https://music.apple.com/us/album/pilatus-mountain-of-dragons-live/1681182666?i=1681184267&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -13308,7 +13548,7 @@
       "recording_title": "Beyond Reach - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1G0q9SgAb0rWpJJmCFNKXy",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/beyond-reach-live/1681181340?i=1681182623&uo=4"
     },
     {
       "year": 2023,
@@ -13318,7 +13558,7 @@
       "recording_title": "Dwa- Księżyce - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0fv5YJ86HvIztisqhWlV5W",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/dwa-ksi%C4%99%C5%BCyce-live/1681181340?i=1681182645&uo=4"
     },
     {
       "year": 2023,
@@ -13328,7 +13568,7 @@
       "recording_title": "Nostalgia - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5feT5fl8XiMGEhEs80cBoF",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/nostalgia-live/1681181340?i=1681182637&uo=4"
     },
     {
       "year": 2023,
@@ -13338,7 +13578,17 @@
       "recording_title": "Made in Bergen - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0vrPBFaTHVJ1IAQ2ocQDio",
-      "apple_music": "https://music.apple.com/us/album/made-in-bergen-live/1680806260?i=1680806471&uo=4"
+      "apple_music": "https://music.apple.com/us/album/made-in-bergen-live/1681181340?i=1681181994&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "7. divisjon",
+      "band": "Hegra Hornmusikklag",
+      "result_piece": "Puszta (Four Gypsi Dances)",
+      "recording_title": "Putza - Live",
+      "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tjKFMSd9AH3X3DoLDSBe1",
+      "apple_music": "https://music.apple.com/us/album/putza-live/1681181340?i=1681181635&uo=4"
     },
     {
       "year": 2023,
@@ -13348,7 +13598,7 @@
       "recording_title": "Aurora Borealis - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1xRcUdPFaavi8tMJvfKlw2",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/aurora-borealis-live/1681181340?i=1681181987&uo=4"
     },
     {
       "year": 2023,
@@ -13358,7 +13608,7 @@
       "recording_title": "Nordlandstoner - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5KzVmwn0rsQNo0QGTe27tP",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/nordlandstoner-live/1681181340?i=1681181642&uo=4"
     },
     {
       "year": 2023,
@@ -13368,7 +13618,7 @@
       "recording_title": "Underlige aftenlufte - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2sebvIOnY25Nk3vh0vC0XN",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/underlige-aftenlufte-live/1681181340?i=1681181653&uo=4"
     },
     {
       "year": 2023,
@@ -13378,7 +13628,7 @@
       "recording_title": "Tales and Myths of Gothia - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/4UMoMVQ0swi2ZNLEfSuVS2",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/tales-and-myths-of-gothia-live/1681181340?i=1681182491&uo=4"
     },
     {
       "year": 2023,
@@ -13388,17 +13638,17 @@
       "recording_title": "Voice of the Vikings - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2xvZyeCwQ0ibkKIynF7RsG",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/voice-of-the-vikings-live/1681181340?i=1681182483&uo=4"
     },
     {
       "year": 2023,
       "division": "7. divisjon",
       "band": "Nidarvoll Ungdomskorps",
       "result_piece": "Norsk Rapsodi nr. 1",
-      "recording_title": "Norsk Rapsodi Nr. 1 - Live",
-      "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4vml3HvFIVRGaJ9jnXznSZ",
-      "apple_music": "https://music.apple.com/us/album/norsk-rapsodi-nr-1-live/1680515141?i=1680515799&uo=4"
+      "recording_title": "Norsk Rapsodi nr. 1 - Live",
+      "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6SZQXtZugvkIu348UJR5Lq",
+      "apple_music": "https://music.apple.com/us/album/norsk-rapsodi-nr-1-live/1681181340?i=1681181633&uo=4"
     },
     {
       "year": 2023,
@@ -13408,7 +13658,7 @@
       "recording_title": "Golden Peak - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/19kkCGzRIOCQoMqynumKiq",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/golden-peak-live/1681181340?i=1681181352&uo=4"
     },
     {
       "year": 2023,
@@ -13418,7 +13668,7 @@
       "recording_title": "Concita for Band - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1cwuejtxNkho05LPYcLAh9",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/concita-for-band-live/1681181340?i=1681182013&uo=4"
     },
     {
       "year": 2023,
@@ -13428,7 +13678,7 @@
       "recording_title": "Journey Through Orion - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1A5geha2HoDpu95hgWvLiw",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/journey-through-orion-live/1681181340?i=1681182288&uo=4"
     },
     {
       "year": 2023,
@@ -13438,7 +13688,7 @@
       "recording_title": "Three Brass Cats: I: Mr Jums - II. Black Sam - III. Borage - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5SNnnEgMOuuM0k6fw8nvel",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/three-brass-cats-i-mr-jums-ii-black-sam-iii-borage-live/1681181340?i=1681182291&uo=4"
     },
     {
       "year": 2023,
@@ -13448,7 +13698,7 @@
       "recording_title": "Utopia - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0sjW42NdwgQViQSrtNEn7K",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/utopia-live/1681181340?i=1681182618&uo=4"
     },
     {
       "year": 2023,
@@ -13458,7 +13708,7 @@
       "recording_title": "Schaffs Mit Mir, Gott - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2IIEbXGOSKWzrIKX1p4Tvc",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/schaffs-mit-mir-gott-live/1681181340?i=1681182302&uo=4"
     },
     {
       "year": 2023,
@@ -13468,7 +13718,7 @@
       "recording_title": "The Legend of Maracaibo - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1adm583ptVFxCD44o7VJk6",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/the-legend-of-maracaibo-live/1681181340?i=1681182478&uo=4"
     },
     {
       "year": 2023,
@@ -13485,10 +13735,10 @@
       "division": "Elite",
       "band": "Bjergsted Blåseensemble",
       "result_piece": "Norsk Rapsodi nr. 1",
-      "recording_title": "Norsk Rapsodi Nr. 1 - Live",
+      "recording_title": "Norsk Rapsodi No. 1 - Live",
       "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4vml3HvFIVRGaJ9jnXznSZ",
-      "apple_music": "https://music.apple.com/us/album/norsk-rapsodi-nr-1-live/1680515141?i=1680515799&uo=4"
+      "spotify": "https://open.spotify.com/track/62SNgYIq8QSCOhAW4nYJFS",
+      "apple_music": "https://music.apple.com/us/album/norsk-rapsodi-no-1-live/1680515141?i=1680515674&uo=4"
     },
     {
       "year": 2023,
@@ -13543,6 +13793,16 @@
     {
       "year": 2023,
       "division": "Elite",
+      "band": "Greåker Musikkorps",
+      "result_piece": "Symphony no. 4",
+      "recording_title": "Symphony No. 4 - Live",
+      "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3gMUdgZ3U7gsghdsYkL05f",
+      "apple_music": "https://music.apple.com/us/album/symphony-no-4-live/1680515141?i=1680515326&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "Elite",
       "band": "Kolbotn Konsertorkester",
       "result_piece": "Cerebral Vortex",
       "recording_title": "Cerebral Vortex - Live",
@@ -13559,6 +13819,16 @@
       "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/2hOJvufmh7Gs74ZTr1VEiV",
       "apple_music": "https://music.apple.com/us/album/det-gamle-kvernhuset-op-204-windband-live/1680515141?i=1680515513&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "Elite",
+      "band": "Kolbotn Konsertorkester",
+      "result_piece": "Redline Tango",
+      "recording_title": "Redline Tango - Live",
+      "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5kvnDssiuvXAfttLGSEAvk",
+      "apple_music": "https://music.apple.com/us/album/redline-tango-live/1680515141?i=1680515533&uo=4"
     },
     {
       "year": 2023,
@@ -13659,6 +13929,16 @@
       "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/5GWA4MsyQdOIBbZGXPaSid",
       "apple_music": "https://music.apple.com/us/album/homenaje-a-joaquin-sorolla-live/1680515141?i=1680515783&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "Elite",
+      "band": "Strusshamn Musikkforening",
+      "result_piece": "Redline Tango",
+      "recording_title": "Redline Tango - Live",
+      "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0fJ7wgPN4AyeFZJt4LwKFV",
+      "apple_music": "https://music.apple.com/us/album/redline-tango-live/1680515141?i=1680515779&uo=4"
     },
     {
       "year": 2024,

--- a/apps/band-positions/public/data/streaming/wind/2016.json
+++ b/apps/band-positions/public/data/streaming/wind/2016.json
@@ -5,62 +5,362 @@
     {
       "year": 2016,
       "division": "1. divisjon",
+      "band": "Borge Musikkorps",
+      "result_piece": "Cheetah",
+      "recording_title": "Cheetah",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/0PukZLpxJOyuO085F456BB",
+      "apple_music": "https://music.apple.com/us/album/cheetah/1095046265?i=1095046594&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Borge Musikkorps",
+      "result_piece": "Theme and Variations for Wind Band, Op. 43a",
+      "recording_title": "Theme and Variations",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/4FFAjKdfilkDQNYoMa45cL",
+      "apple_music": "https://music.apple.com/us/album/theme-and-variations/1095046265?i=1095046595&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Byneset Musikkorps",
+      "result_piece": "Homenaje a Joaquìn Sorolla Cuados Sinfònicos",
+      "recording_title": "Homenaje a Joaquin Sorolla - Byneset",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/7CtEys5Mf7J1uXGbvAFWy9",
+      "apple_music": "https://music.apple.com/us/album/homenaje-a-joaquin-sorolla-byneset/1095046265?i=1095046596&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Drammen Konsertorkester",
+      "result_piece": "Symphonic Metamorphosis of themes by Carl Maria von Weber",
+      "recording_title": "Symphonic Metamorphosis on Themes by Carl Maria von Weber",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/3RPTAxmoWal70UaOio3C33",
+      "apple_music": "https://music.apple.com/us/album/symphonic-metamorphosis-on-themes-by-carl-maria-von-weber/1095046265?i=1095046640&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Kolbotn Konsertorkester",
+      "result_piece": "Breaking Another Wall",
+      "recording_title": "Breaking Another Wall",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/1qvyHvKbc639A1ftrUivz1",
+      "apple_music": "https://music.apple.com/us/album/breaking-another-wall/1095046265?i=1095046651&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Kolbotn Konsertorkester",
+      "result_piece": "Lux Aurumque",
+      "recording_title": "Lux Aurumque",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/5naEyEChaeOcYmWnhFAFQy",
+      "apple_music": "https://music.apple.com/us/album/lux-aurumque/1095046265?i=1095046652&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Lisleby Musikkorps",
+      "result_piece": "Konzertmusik Für Blasorchester",
+      "recording_title": "Konzertmusik Für Blasorchester",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/3nSPioiaKL12He375iDDUP",
+      "apple_music": "https://music.apple.com/us/album/konzertmusik-f%C3%BCr-blasorchester/1095046265?i=1095046591&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
       "band": "Lisleby Musikkorps",
       "result_piece": "Overture on a March",
-      "recording_title": "Overture to a New Age",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age/1112522030?i=1112523078&uo=4"
+      "recording_title": "Overture on a March",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/4distdOwwwHTlTGcgEH9jm",
+      "apple_music": "https://music.apple.com/us/album/overture-on-a-march/1095046265?i=1095046587&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Lørenskog Musikkorps",
+      "result_piece": "Danzón no. 2",
+      "recording_title": "Danzón no. 2",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/4lVfByi0Th9RU68DHKBfjg",
+      "apple_music": "https://music.apple.com/us/album/danz%C3%B3n-no-2/1095046265?i=1095046644&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Lørenskog Musikkorps",
+      "result_piece": "Sketches on a Tudor Psalm",
+      "recording_title": "Sketches on a Tudor Psalm",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/4i8MpJj44XO7tZGyTlHUcU",
+      "apple_music": "https://music.apple.com/us/album/sketches-on-a-tudor-psalm/1095046265?i=1095046643&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Mo Hornmusikk",
+      "result_piece": "Homenaje a Joaquìn Sorolla Cuados Sinfònicos",
+      "recording_title": "Homenaje a Joaquin Sorolla - Mo",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/17d33SDVl1TmD2I6r0AzAB",
+      "apple_music": "https://music.apple.com/us/album/homenaje-a-joaquin-sorolla-mo/1095046265?i=1095046638&uo=4"
     },
     {
       "year": 2016,
       "division": "1. divisjon",
       "band": "Nittedal og Hakadal Janitsjar",
       "result_piece": "Symfoni nr. 1, 3. og 4. sats",
-      "recording_title": "Feste Romane 1-3. og 4.sats",
-      "album": "Nm Janitsjar 2016 - Elitedivisjon",
-      "spotify": "https://open.spotify.com/track/53xRczY3O9yYR8OvKKbQo1",
-      "apple_music": "https://music.apple.com/us/album/feste-romane-1-3-og-4-sats/1095045689?i=1095046031&uo=4"
+      "recording_title": "Symfoni nr. 1, 3 og 4 sats",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/0fYhXcQQN4kCrJPcghWvcm",
+      "apple_music": "https://music.apple.com/us/album/symfoni-nr-1-3-og-4-sats/1095046265?i=1095046732&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Nittedal og Hakadal Janitsjar",
+      "result_piece": "Trista",
+      "recording_title": "Trista",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/1cxzvGSKMQXeOwVkWNhtk4",
+      "apple_music": "https://music.apple.com/us/album/trista/1095046265?i=1095046729&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Sandefjord Musikkorps",
+      "result_piece": "The Soul has Many Motions",
+      "recording_title": "The Soul has Many Motions",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/5LeM8amG1FzvYVxYtvFH6q",
+      "apple_music": "https://music.apple.com/us/album/the-soul-has-many-motions/1095046265?i=1095046649&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Skjold Nesttun Janitsjar",
+      "result_piece": "Pinocchio",
+      "recording_title": "Pinocchio",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/7C7iLlyp4oTpdJ7JU3a6tR",
+      "apple_music": "https://music.apple.com/us/album/pinocchio/1095046265?i=1095046724&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Stavanger Musikkorps av 1919",
+      "result_piece": "Angels in the Architecture",
+      "recording_title": "Angels in the Architecture",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/1w1BtH9JzeGyf8ec7Y13Ik",
+      "apple_music": "https://music.apple.com/us/album/angels-in-the-architecture/1095046265?i=1095046631&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Stavanger Musikkorps av 1919",
+      "result_piece": "Gloriosa, 1. sats",
+      "recording_title": "Gloriosa, 1.sats",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/1Z457phJJvHmNfODraHIuo",
+      "apple_music": "https://music.apple.com/us/album/gloriosa-1-sats/1095046265?i=1095046597&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Strusshamn Musikkforening",
+      "result_piece": "Jungla, Poema ambientado en la Selva Africana",
+      "recording_title": "Jungla, Poema ambientado",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/0pL8ogUWLWXrAYwFRZBGFM",
+      "apple_music": "https://music.apple.com/us/album/jungla-poema-ambientado/1095046265?i=1095046728&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "1. divisjon",
+      "band": "Strusshamn Musikkforening",
+      "result_piece": "La promenade, La Femme a l’ombrelle",
+      "recording_title": "La promenada. La femme a l´ombrelle",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/5wnfz2HJveKT1KGqEExdTG",
+      "apple_music": "https://music.apple.com/us/album/la-promenada-la-femme-a-lombrelle/1095046265?i=1095046727&uo=4"
     },
     {
       "year": 2016,
       "division": "1. divisjon",
       "band": "Vestsidens Musikkorps",
       "result_piece": "Symphony no. 2",
-      "recording_title": "Symphony no. 7",
-      "album": "Nm Janitsjar 2016 - Elitedivisjon",
-      "spotify": "https://open.spotify.com/track/5uv8N6hCCPZp8jEUIZjTTy",
-      "apple_music": "https://music.apple.com/us/album/symphony-no-7/1095045689?i=1095046057&uo=4"
+      "recording_title": "Symphony no. 2",
+      "album": "Nm Janitsjar 2016 - 1.Divisjon",
+      "spotify": "https://open.spotify.com/track/6tw0gp37bbL3mm4nxMOoOV",
+      "apple_music": "https://music.apple.com/us/album/symphony-no-2/1095046265?i=1095046648&uo=4"
     },
     {
       "year": 2016,
       "division": "2. divisjon",
       "band": "Aalesunds Ungdomsmusikkorps",
       "result_piece": "Children of Gala",
-      "recording_title": "Children of Sanchez",
-      "album": "Nm Janitsjar 2016 - 7.Divisjon",
-      "spotify": "https://open.spotify.com/track/4qoIc6iD2ZhW6LuSUJcIIA",
-      "apple_music": null
+      "recording_title": "Children of Gala",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/children-of-gala/1095042036?i=1095042393&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Aalesunds Ungdomsmusikkorps",
+      "result_piece": "Dusk",
+      "recording_title": "Dusk",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/dusk/1095042036?i=1095042395&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Aalesunds Ungdomsmusikkorps",
+      "result_piece": "O Waly, Waly",
+      "recording_title": "O Waly, Waly",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/o-waly-waly/1095042036?i=1095042431&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Alvøens Musikkforening",
+      "result_piece": "Paris Sketches",
+      "recording_title": "Paris Sketches - Alvøens",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/paris-sketches-alv%C3%B8ens/1095042036?i=1095042507&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Arendal Byorkester",
+      "result_piece": "Abide With Me",
+      "recording_title": "Abide With Me",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/abide-with-me/1095042036?i=1095042511&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Arendal Byorkester",
+      "result_piece": "Die Fledermaus, Overture",
+      "recording_title": "Die Fledermaus: Overture",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/die-fledermaus-overture/1095042036?i=1095042508&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Arendal Byorkester",
+      "result_piece": "Festmarsj",
+      "recording_title": "Festmarsj",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/festmarsj/1095042036?i=1095042510&uo=4"
     },
     {
       "year": 2016,
       "division": "2. divisjon",
       "band": "Bispehaugen Ungdomskorps",
       "result_piece": "Arabesque",
-      "recording_title": "Arabesque",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
+      "recording_title": "Arabesque - Bispehaugen",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
       "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/arabesque/1110700233?i=1110701789&uo=4"
+      "apple_music": "https://music.apple.com/us/album/arabesque-bispehaugen/1095042036?i=1095042504&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Bispehaugen Ungdomskorps",
+      "result_piece": "Pinocchio",
+      "recording_title": "Pinocchio",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/pinocchio/1095042036?i=1095042500&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Bjølsen Ungdomskorps",
+      "result_piece": "Danceries",
+      "recording_title": "Danceries",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/danceries/1095042036?i=1095042499&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Gjøvik Bykorps",
+      "result_piece": "Sunrise at Angel`s Gate",
+      "recording_title": "Sunrise at Angel's Gate",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/sunrise-at-angels-gate/1095042036?i=1095042389&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Gjøvik Bykorps",
+      "result_piece": "Symphonic Moment",
+      "recording_title": "Symphonic Moment",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/symphonic-moment/1095042036?i=1095042390&uo=4"
     },
     {
       "year": 2016,
       "division": "2. divisjon",
       "band": "Halsen Musikkforening",
       "result_piece": "Third Suite for Band (Scenes de Ballet)",
-      "recording_title": "Second Suite for Band",
+      "recording_title": "First Suite for Band, 1 sats",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/3J8lUZlqbHqGE0cXQisHAN",
-      "apple_music": "https://music.apple.com/us/album/second-suite-for-band/1112522030?i=1112523095&uo=4"
+      "spotify": "https://open.spotify.com/track/27QT3DSLus2ONcL93K2LQq",
+      "apple_music": "https://music.apple.com/us/album/third-suite-for-band/1095042036?i=1095042432&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Hov Musikkorps",
+      "result_piece": "Fantasy Variations on a Theme by Niccolo Paganini",
+      "recording_title": "Fantasy Variations on a Theme by Nicco Paganini",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/fantasy-variations-on-a-theme-by-nicco-paganini/1095042036?i=1095042492&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Sagene Janitsjarkorps",
+      "result_piece": "Blue Shades",
+      "recording_title": "Blues Shades",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/blues-shades/1095042036?i=1095042433&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Sagene Janitsjarkorps",
+      "result_piece": "The Year of the Dragon, 2. sats",
+      "recording_title": "The Year of the Dragon, 2.sats",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/the-year-of-the-dragon-2-sats/1095042036?i=1095042441&uo=4"
     },
     {
       "year": 2016,
@@ -68,19 +368,99 @@
       "band": "Sande Musikkorps",
       "result_piece": "Saga Candida",
       "recording_title": "Saga Candida",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
       "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/saga-candida/1110700233?i=1110701733&uo=4"
+      "apple_music": "https://music.apple.com/us/album/saga-candida/1095042036?i=1095042456&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Sinsen Konsertorkester",
+      "result_piece": "From Ancient Times",
+      "recording_title": "From Ancient Times",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/from-ancient-times/1095042036?i=1095042566&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Stabekk Janitsjarorkester",
+      "result_piece": "Det gamle kvernhuset",
+      "recording_title": "Det Gamle Kvernhuset",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/det-gamle-kvernhuset/1095042036?i=1095042452&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Stabekk Janitsjarorkester",
+      "result_piece": "Fanfare and Scherzo",
+      "recording_title": "Fanfare and Scherzo",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/fanfare-and-scherzo/1095042036?i=1095042449&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Stabekk Janitsjarorkester",
+      "result_piece": "Symphonic Movement",
+      "recording_title": "Symphonic Movement",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/symphonic-movement/1095042036?i=1095042455&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Sykkylven Janitsjarorkester",
+      "result_piece": "Paris Sketches",
+      "recording_title": "Paris Sketches - Sykkylven",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/paris-sketches-sykkylven/1095042036?i=1095042494&uo=4"
     },
     {
       "year": 2016,
       "division": "2. divisjon",
       "band": "Tromsø Orkesterforenings Janitsjarkorps",
       "result_piece": "Arabesque",
-      "recording_title": "Arabesque",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
+      "recording_title": "Arabesque - Tromsø",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
       "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/arabesque/1110700233?i=1110701789&uo=4"
+      "apple_music": "https://music.apple.com/us/album/arabesque-troms%C3%B8/1095042036?i=1095042567&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Tromsø Orkesterforenings Janitsjarkorps",
+      "result_piece": "Scootin' on Hardrock",
+      "recording_title": "Scootin'on Hardrock",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/scootinon-hardrock/1095042036?i=1095042573&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Tønsberg Janitsjarkorps",
+      "result_piece": "Symphony for Wind Orchestra",
+      "recording_title": "Symphony for Wind Orchestra - Montage",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/symphony-for-wind-orchestra-montage/1095042036?i=1095042448&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "2. divisjon",
+      "band": "Ådalsbruk Musikkforening",
+      "result_piece": "Journey to the Centre of the Earth",
+      "recording_title": "Journey to the Centre of the Earth",
+      "album": "Nm Janitsjar 2016 - 2.divisjon",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/journey-to-the-centre-of-the-earth/1095042036?i=1095042497&uo=4"
     },
     {
       "year": 2016,
@@ -88,8 +468,8 @@
       "band": "Asker Musikkorps",
       "result_piece": "Hispanola",
       "recording_title": "Hispaniola",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/25oA4mxTnlwAYUCoHAkHyj",
       "apple_music": "https://music.apple.com/us/album/hispaniola/1110700233?i=1110701782&uo=4"
     },
     {
@@ -98,8 +478,8 @@
       "band": "Asker og Bærum Ungdomskorps",
       "result_piece": "Saga Candida",
       "recording_title": "Saga Candida",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/1QYLO8H8VfOAooVmw1eXOJ",
       "apple_music": "https://music.apple.com/us/album/saga-candida/1110700233?i=1110701733&uo=4"
     },
     {
@@ -108,8 +488,8 @@
       "band": "Bodø Harmonimusikk",
       "result_piece": "Bandancing",
       "recording_title": "Bandancing",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/3EKicSYin9Ics1A7PaoKyg",
       "apple_music": "https://music.apple.com/us/album/bandancing/1110700233?i=1110701779&uo=4"
     },
     {
@@ -117,9 +497,9 @@
       "division": "3. divisjon",
       "band": "Fåberg Musikkforening",
       "result_piece": "The Seasons",
-      "recording_title": "Sea Songs",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/2BKTd4747sVXce3E3ySJKS",
+      "recording_title": "The Seasons",
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/6e6lc2BrUn8kX1drHED5pI",
       "apple_music": "https://music.apple.com/us/album/the-seasons/1110700233?i=1110701775&uo=4"
     },
     {
@@ -128,8 +508,8 @@
       "band": "Heimdal Musikkorps",
       "result_piece": "Arabesque",
       "recording_title": "Arabesque",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/6i6QsPa8T4yv6G3GSFdcD9",
       "apple_music": "https://music.apple.com/us/album/arabesque/1110700233?i=1110701789&uo=4"
     },
     {
@@ -137,10 +517,10 @@
       "division": "3. divisjon",
       "band": "Heimdal Musikkorps",
       "result_piece": "Evolutions",
-      "recording_title": "Evolutions",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/evolutions/1110700233?i=1110701788&uo=4"
+      "recording_title": "Foundation",
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/6LaTAwRAnlR0qeatWCHd2U",
+      "apple_music": "https://music.apple.com/us/album/foundation/1110700233?i=1110701781&uo=4"
     },
     {
       "year": 2016,
@@ -148,8 +528,8 @@
       "band": "Hovin Musikkorps",
       "result_piece": "Foundation",
       "recording_title": "Foundation",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/6LaTAwRAnlR0qeatWCHd2U",
       "apple_music": "https://music.apple.com/us/album/foundation/1110700233?i=1110701781&uo=4"
     },
     {
@@ -158,8 +538,8 @@
       "band": "Lungegaardens Musikkorps",
       "result_piece": "Armenian Dances, Part 1",
       "recording_title": "Armenian Dances, Pt. 1",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/7E6o4l230iM6eaHXAPGvxD",
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/2JmwKHl9sG5D384nHZ3tLy",
       "apple_music": "https://music.apple.com/us/album/armenian-dances-part-1/1110700233?i=1110701783&uo=4"
     },
     {
@@ -167,9 +547,9 @@
       "division": "3. divisjon",
       "band": "Melhus Janitsjarkorps",
       "result_piece": "Music for Life",
-      "recording_title": "Music for a festival",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/6d6hiK8fiIAz1FyXFjtp9R",
+      "recording_title": "Music for Life",
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/2WifILblema52Th4vCbcqq",
       "apple_music": "https://music.apple.com/us/album/music-for-life/1110700233?i=1110701774&uo=4"
     },
     {
@@ -178,8 +558,8 @@
       "band": "Melhus Janitsjarkorps",
       "result_piece": "Perthshire Majesty",
       "recording_title": "Perthshire Majesty",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/7EYhvUVkcRPLObGruaNkXV",
       "apple_music": "https://music.apple.com/us/album/perthshire-majesty/1110700233?i=1110701773&uo=4"
     },
     {
@@ -188,8 +568,8 @@
       "band": "Oppegård Janitsjar",
       "result_piece": "Variations on a Theme of Robert Schumann (\"The Happy Farmer\")",
       "recording_title": "Variations on a Theme of Robert Schumann",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/7q2VAJh9Sfv5IYAJiZ2ywB",
       "apple_music": "https://music.apple.com/us/album/variations-on-a-theme-of-robert-schumann/1110700233?i=1110701787&uo=4"
     },
     {
@@ -198,8 +578,8 @@
       "band": "Os Musikkforening",
       "result_piece": "Corsican Litany",
       "recording_title": "Corsican Litany",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/0sYk7iIOohiMhA2WGESixy",
       "apple_music": "https://music.apple.com/us/album/corsican-litany/1110700233?i=1110701735&uo=4"
     },
     {
@@ -208,8 +588,8 @@
       "band": "Os Musikkforening",
       "result_piece": "Hjalarljod",
       "recording_title": "Hjalarljod",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/2jC4L9oLstfV1hJCVzCFA4",
       "apple_music": "https://music.apple.com/us/album/hjalarljod/1110700233?i=1110701734&uo=4"
     },
     {
@@ -218,8 +598,8 @@
       "band": "Oslo Postorkester",
       "result_piece": "The Saga of Haakon the Good",
       "recording_title": "Tha Saga of Haakon the Good",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/2y9K1h0cTzdbKdW3sPbVMt",
       "apple_music": "https://music.apple.com/us/album/tha-saga-of-haakon-the-good/1110700233?i=1110701732&uo=4"
     },
     {
@@ -228,9 +608,19 @@
       "band": "Ranheim Musikkforening",
       "result_piece": "October",
       "recording_title": "October",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/7w8m8O8DmrR71D8D3w9iDU",
       "apple_music": "https://music.apple.com/us/album/october/1110700233?i=1110701737&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "3. divisjon",
+      "band": "Ranheim Musikkforening",
+      "result_piece": "Wild Nights!",
+      "recording_title": "Wild Nights",
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/3DnmDeQvOExc5tM3YZ4wmc",
+      "apple_music": "https://music.apple.com/us/album/wild-nights/1110700233?i=1110701738&uo=4"
     },
     {
       "year": 2016,
@@ -238,8 +628,8 @@
       "band": "Skedsmo Janitsjarorkester",
       "result_piece": "Sacred Harp",
       "recording_title": "Sacred Harp",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/4yuc1un2d4u0j00S4pdEG6",
       "apple_music": "https://music.apple.com/us/album/sacred-harp/1110700233?i=1110701772&uo=4"
     },
     {
@@ -248,8 +638,8 @@
       "band": "Skedsmo Janitsjarorkester",
       "result_piece": "Seven Hills Overture",
       "recording_title": "Seven Hills Overture",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/21hvNHGfZAENkYNx8ByjG8",
       "apple_music": "https://music.apple.com/us/album/seven-hills-overture/1110700233?i=1110701739&uo=4"
     },
     {
@@ -258,8 +648,8 @@
       "band": "Strindheim Janitsjar",
       "result_piece": "Incantation and Dance",
       "recording_title": "Incantation and Dance",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/7EXdHSeGvVljzd3GrkZaV4",
       "apple_music": "https://music.apple.com/us/album/incantation-and-dance/1110700233?i=1110701778&uo=4"
     },
     {
@@ -268,8 +658,8 @@
       "band": "Strindheim Janitsjar",
       "result_piece": "Mother Earth (A Fanfare)",
       "recording_title": "Mother Earth",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/6HdL4n6N2f8sUlNQppj0Sy",
       "apple_music": "https://music.apple.com/us/album/mother-earth/1110700233?i=1110701776&uo=4"
     },
     {
@@ -278,8 +668,8 @@
       "band": "Svolvær Musikkforening",
       "result_piece": "subTERRA",
       "recording_title": "subTERRA",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/33nm5jc1FmZOwxsQTHagIp",
       "apple_music": "https://music.apple.com/us/album/subterra/1110700233?i=1110701780&uo=4"
     },
     {
@@ -288,9 +678,9 @@
       "band": "Åsane Musikklag",
       "result_piece": "The Saga of Haakon the Good",
       "recording_title": "Tha Saga of Haakon the Good",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/tha-saga-of-haakon-the-good/1110700233?i=1110701732&uo=4"
+      "album": "Nm Janitsjar 2016 - 3.Divisjon",
+      "spotify": "https://open.spotify.com/track/10mAB8HuwO0YayJ49xdRCE",
+      "apple_music": "https://music.apple.com/us/album/tha-saga-of-haakon-the-good/1110700233?i=1110701736&uo=4"
     },
     {
       "year": 2016,
@@ -310,7 +700,7 @@
       "recording_title": "Music for a festival",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
       "spotify": "https://open.spotify.com/track/6d6hiK8fiIAz1FyXFjtp9R",
-      "apple_music": "https://music.apple.com/us/album/music-for-a-solemnity/1112522030?i=1112523076&uo=4"
+      "apple_music": "https://music.apple.com/us/album/music-for-life/1110700233?i=1110701774&uo=4"
     },
     {
       "year": 2016,
@@ -330,7 +720,7 @@
       "recording_title": "Overture Allemande",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
       "spotify": "https://open.spotify.com/track/3aYpyT9cPUjdOBaCooKM4a",
-      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age/1112522030?i=1112523078&uo=4"
+      "apple_music": null
     },
     {
       "year": 2016,
@@ -370,7 +760,7 @@
       "recording_title": "Sea Songs",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
       "spotify": "https://open.spotify.com/track/2BKTd4747sVXce3E3ySJKS",
-      "apple_music": "https://music.apple.com/us/album/the-seasons/1110700233?i=1110701775&uo=4"
+      "apple_music": null
     },
     {
       "year": 2016,
@@ -410,7 +800,17 @@
       "recording_title": "First Suite for Band, 1 sats",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
       "spotify": "https://open.spotify.com/track/27QT3DSLus2ONcL93K2LQq",
-      "apple_music": "https://music.apple.com/us/album/second-suite-for-band/1112522030?i=1112523095&uo=4"
+      "apple_music": null
+    },
+    {
+      "year": 2016,
+      "division": "4. divisjon",
+      "band": "Musikkforeningen Viken",
+      "result_piece": "Så skimrande var aldrig havet",
+      "recording_title": "First Suite for Band, 1 sats",
+      "album": "Nm Janitsjar 2016 - 4.Divisjon",
+      "spotify": "https://open.spotify.com/track/27QT3DSLus2ONcL93K2LQq",
+      "apple_music": null
     },
     {
       "year": 2016,
@@ -437,9 +837,9 @@
       "division": "4. divisjon",
       "band": "Nes Janitsjarkorps",
       "result_piece": "Machu Picchu - City in the sky - the mystery of the hidden sun Temple",
-      "recording_title": "Machu Picchu City in the Sky",
+      "recording_title": "Machu Picchu City in the Sky - Nes",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/6DsEB9csmUxNF21GpmXTww",
+      "spotify": "https://open.spotify.com/track/4gRSixW9cREpezx8fvDZGE",
       "apple_music": null
     },
     {
@@ -447,10 +847,10 @@
       "division": "4. divisjon",
       "band": "Prosjekt MMXIX",
       "result_piece": "Armenian Dances, Part 1",
-      "recording_title": "Armenian Dances, Pt. 1",
+      "recording_title": "Armenian Dances",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/7E6o4l230iM6eaHXAPGvxD",
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-part-1/1110700233?i=1110701783&uo=4"
+      "spotify": "https://open.spotify.com/track/14DiFKscGosAw675PU7FOX",
+      "apple_music": null
     },
     {
       "year": 2016,
@@ -470,7 +870,7 @@
       "recording_title": "Banja Luka",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
       "spotify": "https://open.spotify.com/track/786Pbi5MonjqUzKm0fDOBG",
-      "apple_music": "https://music.apple.com/us/album/banja-luka/1112522030?i=1112523040&uo=4"
+      "apple_music": null
     },
     {
       "year": 2016,
@@ -497,10 +897,10 @@
       "division": "4. divisjon",
       "band": "Tvedestrand Musikkorps",
       "result_piece": "Second Suite in F for Military Band",
-      "recording_title": "First Suite in Eb for Military Band",
-      "album": "Nm Janitsjar 2016 - 7.Divisjon",
-      "spotify": "https://open.spotify.com/track/2oEovqafFDvwHFREZdcqgt",
-      "apple_music": "https://music.apple.com/us/album/second-suite-for-band/1112522030?i=1112523095&uo=4"
+      "recording_title": "Second Suite in F Major",
+      "album": "Nm Janitsjar 2016 - 4.Divisjon",
+      "spotify": "https://open.spotify.com/track/7hHRgPOt6P8mxHk1i1hup5",
+      "apple_music": null
     },
     {
       "year": 2016,
@@ -510,7 +910,7 @@
       "recording_title": "Second Suite for Band",
       "album": "Nm Janitsjar 2016 - 4.Divisjon",
       "spotify": "https://open.spotify.com/track/3J8lUZlqbHqGE0cXQisHAN",
-      "apple_music": "https://music.apple.com/us/album/second-suite-for-band/1112522030?i=1112523095&uo=4"
+      "apple_music": null
     },
     {
       "year": 2016,
@@ -528,8 +928,8 @@
       "band": "Alvdal-Tynset Janitsjarkorps",
       "result_piece": "Dies Infernus",
       "recording_title": "Dies Infernus",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/0BXrUy82ID3d7TXx6LW8aP",
       "apple_music": "https://music.apple.com/us/album/dies-infernus/1112522030?i=1112523098&uo=4"
     },
     {
@@ -538,8 +938,8 @@
       "band": "Alvdal-Tynset Janitsjarkorps",
       "result_piece": "Hennepin County Dawn",
       "recording_title": "Hennepin County Dawn",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/5RSCQQPm4hyqTmay8ZroWk",
       "apple_music": "https://music.apple.com/us/album/hennepin-county-dawn/1112522030?i=1112523097&uo=4"
     },
     {
@@ -548,9 +948,19 @@
       "band": "Alvdal-Tynset Janitsjarkorps",
       "result_piece": "Scramble",
       "recording_title": "Scramble",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/6fupKaJmgMEqSd2PUfMoRc",
       "apple_music": "https://music.apple.com/us/album/scramble/1112522030?i=1112523096&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "5. divisjon",
+      "band": "Bømlo Janitsjar",
+      "result_piece": "Overture to a new Age",
+      "recording_title": "Overture to a New Age",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/7HpvhcKE4MbHdFiiCBOEbY",
+      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age/1112522030?i=1112523078&uo=4"
     },
     {
       "year": 2016,
@@ -558,8 +968,8 @@
       "band": "Haugesund Janitsjarorkester",
       "result_piece": "Goddess of Fire",
       "recording_title": "Goddess of Fire",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/246yq0arhhwy1F8E5UXiuF",
       "apple_music": "https://music.apple.com/us/album/goddess-of-fire/1112522030?i=1112523082&uo=4"
     },
     {
@@ -567,9 +977,9 @@
       "division": "5. divisjon",
       "band": "Haugesund Janitsjarorkester",
       "result_piece": "Ride",
-      "recording_title": "El Jardin de Las Hespérides",
-      "album": "Nm Janitsjar 2016 - Elitedivisjon",
-      "spotify": "https://open.spotify.com/track/1XfnaO7gm6SowHYM94dWxq",
+      "recording_title": "Ride",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/36HQSUFIkIu8BdfBVBt1K6",
       "apple_music": "https://music.apple.com/us/album/ride/1112522030?i=1112523083&uo=4"
     },
     {
@@ -578,8 +988,8 @@
       "band": "Hegra Hornmusikklag",
       "result_piece": "Fra Borge",
       "recording_title": "Fra Borge",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/337hnc63PkuZZp5qkkRFRF",
       "apple_music": "https://music.apple.com/us/album/fra-borge/1112522030?i=1112523112&uo=4"
     },
     {
@@ -588,8 +998,8 @@
       "band": "Hegra Hornmusikklag",
       "result_piece": "Persis",
       "recording_title": "Persis",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/5b9WczHc1W5DkjkiqVRnN6",
       "apple_music": "https://music.apple.com/us/album/persis/1112522030?i=1112523109&uo=4"
     },
     {
@@ -598,8 +1008,8 @@
       "band": "Malvik Musikkorps",
       "result_piece": "Dawn of a New Day",
       "recording_title": "Dawn of a New Day",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/0W4PWYVrRsU3tAOYZy085E",
       "apple_music": "https://music.apple.com/us/album/dawn-of-a-new-day/1112522030?i=1112523080&uo=4"
     },
     {
@@ -608,8 +1018,8 @@
       "band": "Malvik Musikkorps",
       "result_piece": "Åkernesset",
       "recording_title": "Åkernesset",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/7owMRhOEO8aLtzDpnBBwb3",
       "apple_music": "https://music.apple.com/us/album/%C3%A5kernesset/1112522030?i=1112523079&uo=4"
     },
     {
@@ -618,8 +1028,8 @@
       "band": "Moss og omegn Janitsjar",
       "result_piece": "Overture Jubiloso",
       "recording_title": "Overture Jubiloso",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/7CaZbHNP5BCEjQmwMLrHSU",
       "apple_music": "https://music.apple.com/us/album/overture-jubiloso/1112522030?i=1112523085&uo=4"
     },
     {
@@ -627,9 +1037,9 @@
       "division": "5. divisjon",
       "band": "Moss og omegn Janitsjar",
       "result_piece": "Puszta, 1., 2. og 3. sats",
-      "recording_title": "Lincolnshire Posy, 2 og 3 sats",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/5iq7JPAIlS0IEeSoQcBceu",
+      "recording_title": "Putza 1, 2 og 3 sats",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/4eMoyRtNCbp3rZ3XfeuIhd",
       "apple_music": "https://music.apple.com/us/album/putza-1-2-og-3-sats/1112522030?i=1112523084&uo=4"
     },
     {
@@ -638,8 +1048,8 @@
       "band": "Musikklaget Brage",
       "result_piece": "Pentium",
       "recording_title": "Pentium",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/3VesdAKZZhwir7iAGxY4Xc",
       "apple_music": "https://music.apple.com/us/album/pentium/1112522030?i=1112523099&uo=4"
     },
     {
@@ -648,8 +1058,8 @@
       "band": "Musikklaget Brage",
       "result_piece": "Vesuvius",
       "recording_title": "Vesuvius",
-      "album": "Nm Janitsjar 2016 - 7.Divisjon",
-      "spotify": "https://open.spotify.com/track/2IZil3bxeI3PIEJHllunsi",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/4cbvUzult5GOl8twqVEX5K",
       "apple_music": "https://music.apple.com/us/album/vesuvius/1112522030?i=1112523105&uo=4"
     },
     {
@@ -658,8 +1068,8 @@
       "band": "Musikklaget Ulf",
       "result_piece": "Second Suite for Band",
       "recording_title": "Second Suite for Band",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/3J8lUZlqbHqGE0cXQisHAN",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/5WIp1X8EudjnrsXQfHQHrj",
       "apple_music": "https://music.apple.com/us/album/second-suite-for-band/1112522030?i=1112523095&uo=4"
     },
     {
@@ -668,8 +1078,8 @@
       "band": "Nannestad Janitsjarkorps",
       "result_piece": "Banja Luka",
       "recording_title": "Banja Luka",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/786Pbi5MonjqUzKm0fDOBG",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/7wxb4zAPT98KHlYXw56eS4",
       "apple_music": "https://music.apple.com/us/album/banja-luka/1112522030?i=1112523040&uo=4"
     },
     {
@@ -678,8 +1088,8 @@
       "band": "Odda Musikklag",
       "result_piece": "Lebuinus ex Daventria",
       "recording_title": "Lebuinus ex Daventria",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/7MJT9mgXrkhPQpdSEkyJ1D",
       "apple_music": "https://music.apple.com/us/album/lebuinus-ex-daventria/1112522030?i=1112523092&uo=4"
     },
     {
@@ -688,8 +1098,8 @@
       "band": "Ringsaker Janitjsar",
       "result_piece": "Saga Maligna",
       "recording_title": "Saga Maligna",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/2s3nAeL3pfzwYCg1y2Gbvm",
       "apple_music": "https://music.apple.com/us/album/saga-maligna/1112522030?i=1112523113&uo=4"
     },
     {
@@ -697,9 +1107,9 @@
       "division": "5. divisjon",
       "band": "Stord Musikklag",
       "result_piece": "A Boy’s Dream",
-      "recording_title": "A Boy's Dream",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "recording_title": "A Boy´s Dream",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/1aNc54xftEQu1xg7ZnHFrA",
       "apple_music": "https://music.apple.com/us/album/a-boys-dream/1112522030?i=1112523089&uo=4"
     },
     {
@@ -708,8 +1118,8 @@
       "band": "Stord Musikklag",
       "result_piece": "Gloriana",
       "recording_title": "Gloriana",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/79Ayk6U2XtIYfNLxh6M07H",
       "apple_music": "https://music.apple.com/us/album/gloriana/1112522030?i=1112523090&uo=4"
     },
     {
@@ -717,19 +1127,19 @@
       "division": "5. divisjon",
       "band": "Tolga-Os Janitsjar",
       "result_piece": "Banja Luka",
-      "recording_title": "Banja Luka",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/786Pbi5MonjqUzKm0fDOBG",
-      "apple_music": "https://music.apple.com/us/album/banja-luka/1112522030?i=1112523040&uo=4"
+      "recording_title": "Banja Luka - Tolga Os",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/0TI11q8bSl24hlIVLFy1iz",
+      "apple_music": "https://music.apple.com/us/album/banja-luka-tolga-os/1112522030?i=1112523077&uo=4"
     },
     {
       "year": 2016,
       "division": "5. divisjon",
       "band": "Vålerenga Janitsjarkorps",
       "result_piece": "Folk Song Suite for Military Band",
-      "recording_title": "First Suite in Eb for Military Band",
-      "album": "Nm Janitsjar 2016 - 7.Divisjon",
-      "spotify": "https://open.spotify.com/track/2oEovqafFDvwHFREZdcqgt",
+      "recording_title": "Folk Song Suite",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/2JDx9wLkstuFMp6Nvm7N0F",
       "apple_music": "https://music.apple.com/us/album/folk-song-suite/1112522030?i=1112523081&uo=4"
     },
     {
@@ -737,9 +1147,9 @@
       "division": "5. divisjon",
       "band": "Åsnes Hornmusikk",
       "result_piece": "Music for a Solemnity",
-      "recording_title": "Music for a festival",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/6d6hiK8fiIAz1FyXFjtp9R",
+      "recording_title": "Music for a Solemnity",
+      "album": "Nm Janitsjar 2016 - 5.Divisjon",
+      "spotify": "https://open.spotify.com/track/5zXn5g59rMzGOpKP7NqMU4",
       "apple_music": "https://music.apple.com/us/album/music-for-a-solemnity/1112522030?i=1112523076&uo=4"
     },
     {
@@ -747,20 +1157,30 @@
       "division": "6. divisjon",
       "band": "Alversund Musikklag",
       "result_piece": "Music for a Festival",
-      "recording_title": "Music for a festival",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/6d6hiK8fiIAz1FyXFjtp9R",
-      "apple_music": "https://music.apple.com/us/album/music-for-a-solemnity/1112522030?i=1112523076&uo=4"
+      "recording_title": "Music for a Festival -",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/42UGAC5cId0sPfGWqYMOwv",
+      "apple_music": "https://music.apple.com/us/album/music-for-a-festival/1095042410?i=1095043162&uo=4"
     },
     {
       "year": 2016,
       "division": "6. divisjon",
       "band": "Byåsen Musikkorps",
       "result_piece": "Saint and the City",
-      "recording_title": "The Witch and the Saint",
-      "album": "Nm Janitsjar 2016 - 7.Divisjon",
-      "spotify": "https://open.spotify.com/track/1S77hzKabfJjFd4mBHoLPt",
-      "apple_music": null
+      "recording_title": "Saint and the City",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/3PKtSXiAqfQ7lS01dQBBen",
+      "apple_music": "https://music.apple.com/us/album/saint-and-the-city/1095042410?i=1095043155&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Byåsen Musikkorps",
+      "result_piece": "Toccata",
+      "recording_title": "Toccata",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/7h2vhUFpIMEyN4oQYFiALj",
+      "apple_music": "https://music.apple.com/us/album/toccata/1095042410?i=1095043152&uo=4"
     },
     {
       "year": 2016,
@@ -768,29 +1188,69 @@
       "band": "Dokka Musikkorps",
       "result_piece": "Oregon",
       "recording_title": "Oregon",
-      "album": "Nm Janitsjar 2016 - 7.Divisjon",
-      "spotify": "https://open.spotify.com/track/3xdE6Tu1RlPKodGkGpPsIN",
-      "apple_music": null
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/2UlBPpworqrqBHPt94awde",
+      "apple_music": "https://music.apple.com/us/album/oregon/1095042410?i=1095043141&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Fana Musikklag",
+      "result_piece": "Vilela",
+      "recording_title": "Vilela",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/527NBYJgF8pKKHgP4Svker",
+      "apple_music": "https://music.apple.com/us/album/vilela/1095042410?i=1095043161&uo=4"
     },
     {
       "year": 2016,
       "division": "6. divisjon",
       "band": "Fet Janitsjar",
       "result_piece": "Music for a Festival",
-      "recording_title": "Music for a festival",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/6d6hiK8fiIAz1FyXFjtp9R",
-      "apple_music": "https://music.apple.com/us/album/music-for-a-solemnity/1112522030?i=1112523076&uo=4"
+      "recording_title": "Music for a Festival",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/0sfCrZHeR5NAQ0DMHOioRu",
+      "apple_music": "https://music.apple.com/us/album/music-for-a-festival/1095042410?i=1095043145&uo=4"
     },
     {
       "year": 2016,
       "division": "6. divisjon",
       "band": "Glommasvingen Janitsjar",
       "result_piece": "The Witch and the Saint",
-      "recording_title": "The Witch and the Saint",
-      "album": "Nm Janitsjar 2016 - 7.Divisjon",
-      "spotify": "https://open.spotify.com/track/1S77hzKabfJjFd4mBHoLPt",
-      "apple_music": null
+      "recording_title": "The Witch and The Saint",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/70IcLKu3HhJ5yYvx81pFz0",
+      "apple_music": "https://music.apple.com/us/album/the-witch-and-the-saint/1095042410?i=1095043156&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Hadeland Janitsjar",
+      "result_piece": "Jericho",
+      "recording_title": "Jericho",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/4bz9dLjBB6oemMgnnjWpiv",
+      "apple_music": "https://music.apple.com/us/album/jericho/1095042410?i=1095043142&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Jernbanens Musikkorps Oslo",
+      "result_piece": "Puszta (Four Gypsi Dances)",
+      "recording_title": "Puszta",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/3SPYBRYCVrY5J6ePe0v3bk",
+      "apple_music": "https://music.apple.com/us/album/puszta/1095042410?i=1095043239&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Klæbu Musikkorps",
+      "result_piece": "Fest Polonaise, Op. 12",
+      "recording_title": "Fest polonaise, op.12",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/3xvxJhgbxAhvezBjamkrht",
+      "apple_music": "https://music.apple.com/us/album/fest-polonaise-op-12/1095042410?i=1095043160&uo=4"
     },
     {
       "year": 2016,
@@ -798,9 +1258,9 @@
       "band": "Musikklaget Ustemt",
       "result_piece": "Hispanola",
       "recording_title": "Hispaniola",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/hispaniola/1110700233?i=1110701782&uo=4"
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/6vP4siBqDqexGTrO5sutP8",
+      "apple_music": "https://music.apple.com/us/album/hispaniola/1095042410?i=1095043158&uo=4"
     },
     {
       "year": 2016,
@@ -808,19 +1268,69 @@
       "band": "Musikkorpset TEMPO",
       "result_piece": "Fate of the Gods",
       "recording_title": "Fate of the Gods",
-      "album": "Nm Janitsjar 2016 - 4.Divisjon",
-      "spotify": "https://open.spotify.com/track/4OYpJPqOyZWR58znH3JAl0",
-      "apple_music": null
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/59L8S5LTkbQDhL8heaKhdL",
+      "apple_music": "https://music.apple.com/us/album/fate-of-the-gods/1095042410?i=1095043151&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Musikkorpset TEMPO",
+      "result_piece": "Ved Rondane",
+      "recording_title": "Ved Rondane",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/7Ca4og0j9jIirRGl8hjsXf",
+      "apple_music": "https://music.apple.com/us/album/ved-rondane/1095042410?i=1095043146&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Namsos Musikkorps",
+      "result_piece": "Puszta (Four Gypsi Dances)",
+      "recording_title": "Puszta.",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/0QE8Nc6wCFj8wLLGJ4ZSI5",
+      "apple_music": "https://music.apple.com/us/album/puszta/1095042410?i=1095043135&uo=4"
     },
     {
       "year": 2016,
       "division": "6. divisjon",
       "band": "Nordre Aker Janitsjar/Grefsen Ungdomskorps",
       "result_piece": "Birth of a New Day",
-      "recording_title": "Dawn of a New Day",
-      "album": "Nm Janitsjar 2016 - 5.divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/dawn-of-a-new-day/1112522030?i=1112523080&uo=4"
+      "recording_title": "Birth of a New Day",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/64G1ZmCCOKSoB8XsozHlkH",
+      "apple_music": "https://music.apple.com/us/album/birth-of-a-new-day/1095042410?i=1095043163&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Rælingen Musikklag",
+      "result_piece": "Variations for Band",
+      "recording_title": "Variations for Band",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/38UkKXg6HVFtl2DdCCxmiG",
+      "apple_music": "https://music.apple.com/us/album/variations-for-band/1095042410?i=1095043159&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Skatval Hornmusikklag",
+      "result_piece": "A Song of Hope",
+      "recording_title": "A Song of Hope",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/71cEeEhTStfCYef8RQ4Atc",
+      "apple_music": "https://music.apple.com/us/album/a-song-of-hope/1095042410?i=1095043137&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Skatval Hornmusikklag",
+      "result_piece": "The Light Eternal",
+      "recording_title": "The Light Eternal",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/4wkVzjin4eeCkphdBNhOTD",
+      "apple_music": "https://music.apple.com/us/album/the-light-eternal/1095042410?i=1095043138&uo=4"
     },
     {
       "year": 2016,
@@ -828,9 +1338,19 @@
       "band": "Sofienberg Musikkorps",
       "result_piece": "Mother Earth (A Fanfare)",
       "recording_title": "Mother Earth",
-      "album": "Nm Janitsjar 2016 - 3.divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/mother-earth/1110700233?i=1110701776&uo=4"
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/4LzAFTYPqoxftNjV0q9DzW",
+      "apple_music": "https://music.apple.com/us/album/mother-earth/1095042410?i=1095043236&uo=4"
+    },
+    {
+      "year": 2016,
+      "division": "6. divisjon",
+      "band": "Sofienberg Musikkorps",
+      "result_piece": "Pilatus: Mountain of Dragons",
+      "recording_title": "Pilatus: Mountains of Dragons",
+      "album": "Nm Janitsjar 2016 - 6.Divisjon",
+      "spotify": "https://open.spotify.com/track/7HgukZmL71qfm1NaUjjNvl",
+      "apple_music": "https://music.apple.com/us/album/pilatus-mountains-of-dragons/1095042410?i=1095043212&uo=4"
     },
     {
       "year": 2016,
@@ -1070,7 +1590,7 @@
       "recording_title": "Vesuvius",
       "album": "Nm Janitsjar 2016 - 7.Divisjon",
       "spotify": "https://open.spotify.com/track/2IZil3bxeI3PIEJHllunsi",
-      "apple_music": "https://music.apple.com/us/album/vesuvius/1112522030?i=1112523105&uo=4"
+      "apple_music": null
     },
     {
       "year": 2016,

--- a/apps/band-positions/public/data/streaming/wind/2018.json
+++ b/apps/band-positions/public/data/streaming/wind/2018.json
@@ -5,6 +5,16 @@
     {
       "year": 2018,
       "division": "1. divisjon",
+      "band": "Alvøens Musikkforening",
+      "result_piece": "Sidus",
+      "recording_title": "Sidus",
+      "album": "Nm Janitsjar 2018 - 1 Divisjon",
+      "spotify": "https://open.spotify.com/track/3HTdezlLg8oacDvwdRM68K",
+      "apple_music": "https://music.apple.com/us/album/sidus/1369248829?i=1369248840&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "1. divisjon",
       "band": "Bjergsted Blåseensemble",
       "result_piece": "Festmusik Der Stadt Wien",
       "recording_title": "Festmusik der Stadt Wien",
@@ -19,8 +29,8 @@
       "result_piece": "Stabsarabesk",
       "recording_title": "Stabsarabesk",
       "album": "Nm Janitsjar 2018 - 1 Divisjon",
-      "spotify": "https://open.spotify.com/track/5n4OjpiySkGFliIhg0wWNK",
-      "apple_music": "https://music.apple.com/us/album/stabsarabesk/1369248829?i=1369248836&uo=4"
+      "spotify": "https://open.spotify.com/track/61xWAFPhh3GdqNH0B7rO26",
+      "apple_music": "https://music.apple.com/us/album/stabsarabesk/1369248829?i=1369248847&uo=4"
     },
     {
       "year": 2018,
@@ -86,6 +96,16 @@
       "year": 2018,
       "division": "1. divisjon",
       "band": "Nittedal og Hakadal Janitsjar",
+      "result_piece": "Divertimento",
+      "recording_title": "Divertimento",
+      "album": "Nm Janitsjar 2018 - 1 Divisjon",
+      "spotify": "https://open.spotify.com/track/0enLzjfJ0dsvuXx8NHgDXa",
+      "apple_music": "https://music.apple.com/us/album/divertimento/1369248829?i=1369248838&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "1. divisjon",
+      "band": "Nittedal og Hakadal Janitsjar",
       "result_piece": "Elegia",
       "recording_title": "Elegia",
       "album": "Nm Janitsjar 2018 - 1 Divisjon",
@@ -96,11 +116,31 @@
       "year": 2018,
       "division": "1. divisjon",
       "band": "Sandefjord Musikkorps",
+      "result_piece": "Incantation and Dance",
+      "recording_title": "Incantation and Dance",
+      "album": "Nm Janitsjar 2018 - 1 Divisjon",
+      "spotify": "https://open.spotify.com/track/2W96HF5U9vcY72QkZlsxyJ",
+      "apple_music": "https://music.apple.com/us/album/incantation-and-dance/1369248829?i=1369248850&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "1. divisjon",
+      "band": "Sandefjord Musikkorps",
       "result_piece": "Poéme du Feu",
       "recording_title": "Poème du feu",
       "album": "Nm Janitsjar 2018 - 1 Divisjon",
       "spotify": "https://open.spotify.com/track/5R62YQRea2Y3Tzg26Q1vYf",
       "apple_music": "https://music.apple.com/us/album/po%C3%A8me-du-feu/1369248829?i=1369248849&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "1. divisjon",
+      "band": "Sandvikens Ungdomskorps",
+      "result_piece": "Pequeña Suite para Banda",
+      "recording_title": "Penquena Suite para Band",
+      "album": "Nm Janitsjar 2018 - 1 Divisjon",
+      "spotify": "https://open.spotify.com/track/5UM1W7u989fq0Y639gBigI",
+      "apple_music": "https://music.apple.com/us/album/penquena-suite-para-band/1369248829?i=1369248835&uo=4"
     },
     {
       "year": 2018,
@@ -155,11 +195,21 @@
     {
       "year": 2018,
       "division": "2. divisjon",
+      "band": "Aalesunds Ungdomsmusikkorps",
+      "result_piece": "Saga Candida",
+      "recording_title": "Saga Candida",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/5WJTjiPl3XVDX3Y2cELgmH",
+      "apple_music": "https://music.apple.com/us/album/saga-candida/1369249591?i=1369249596&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "2. divisjon",
       "band": "Asker Musikkorps",
       "result_piece": "Ponte Romano",
       "recording_title": "Ponte Romano",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/1MOmskFuCtDiqqOHM9wyDW",
       "apple_music": "https://music.apple.com/us/album/ponte-romano/1369249591?i=1369249727&uo=4"
     },
     {
@@ -168,8 +218,8 @@
       "band": "Asker Musikkorps",
       "result_piece": "Vesuvius",
       "recording_title": "Vesuvius",
-      "album": "Nm Janitsjar 2018 - 6 Divisjon",
-      "spotify": "https://open.spotify.com/track/6GLQs69zpXI6E7O3Y2sspg",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/5PEdudUFyY2nCcrJS98bvg",
       "apple_music": "https://music.apple.com/us/album/vesuvius/1369249591?i=1369249728&uo=4"
     },
     {
@@ -178,8 +228,8 @@
       "band": "Bispehaugen Ungdomskorps",
       "result_piece": "Luces y Sombras",
       "recording_title": "Luces y Sombras",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/0iILrxzX0C4f3al67qKRve",
       "apple_music": "https://music.apple.com/us/album/luces-y-sombras/1369249591?i=1369249732&uo=4"
     },
     {
@@ -188,8 +238,8 @@
       "band": "Bjølsen Ungdomskorps",
       "result_piece": "Incantation and Dance",
       "recording_title": "Incantation and Dance",
-      "album": "Nm Janitsjar 2018 - 3 Divisjon",
-      "spotify": "https://open.spotify.com/track/7ylXaUVKcSyYHYdePWBVXj",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/5zU6nGu0LPW50TJsCONgnn",
       "apple_music": "https://music.apple.com/us/album/incantation-and-dance/1369249591?i=1369249735&uo=4"
     },
     {
@@ -198,8 +248,8 @@
       "band": "Bjølsen Ungdomskorps",
       "result_piece": "With Heart and Voice",
       "recording_title": "With Heart and Voice",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/6h9nEDTv9O28PbhplKYbq9",
       "apple_music": "https://music.apple.com/us/album/with-heart-and-voice/1369249591?i=1369249736&uo=4"
     },
     {
@@ -208,8 +258,8 @@
       "band": "Gjøvik Bykorps",
       "result_piece": "Dawn Flight",
       "recording_title": "Dawn Flight",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/77s4ND87Z6YCYsoGm0cmmm",
       "apple_music": "https://music.apple.com/us/album/dawn-flight/1369249591?i=1369249742&uo=4"
     },
     {
@@ -218,8 +268,8 @@
       "band": "Gjøvik Bykorps",
       "result_piece": "Gulliver's Travels",
       "recording_title": "Gulliver´s Travels",
-      "album": "Nm Janitsjar 2018 - 7 Divisjon",
-      "spotify": "https://open.spotify.com/track/1dCJyRXADiR19vGw5mmtvx",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/2zZryXtSVzipMefvj9z4RL",
       "apple_music": "https://music.apple.com/us/album/gullivers-travels/1369249591?i=1369249741&uo=4"
     },
     {
@@ -227,9 +277,9 @@
       "division": "2. divisjon",
       "band": "Halsen Musikkforening",
       "result_piece": "Fleodrodum",
-      "recording_title": "\"Fleodrodum\"",
-      "album": "Nm Janitsjar 2018 - 6 Divisjon",
-      "spotify": "https://open.spotify.com/track/56pokXVgpwdKH1fLhjdmEd",
+      "recording_title": "Fleodrodum",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/6rCyVN4v2qbjOoL6MACcRt",
       "apple_music": "https://music.apple.com/us/album/fleodrodum/1369249591?i=1369249598&uo=4"
     },
     {
@@ -238,8 +288,8 @@
       "band": "Hov Musikkorps",
       "result_piece": "La Ville Blanche et Bleue",
       "recording_title": "La Ville Blanche et Bleue",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/0u3gO1p9a7a9i6bVfSmL9J",
       "apple_music": "https://music.apple.com/us/album/la-ville-blanche-et-bleue/1369249591?i=1369249730&uo=4"
     },
     {
@@ -248,8 +298,8 @@
       "band": "Hov Musikkorps",
       "result_piece": "Sketches on a Tudor Psalm",
       "recording_title": "Sketches on a Tudor Psalm",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/3p58vx9Ljhp1oxV72SMWMP",
       "apple_music": "https://music.apple.com/us/album/sketches-on-a-tudor-psalm/1369249591?i=1369249731&uo=4"
     },
     {
@@ -257,10 +307,20 @@
       "division": "2. divisjon",
       "band": "Lungegaardens Musikkorps",
       "result_piece": "Between the Two Rivers",
-      "recording_title": "Between the two Rivers",
-      "album": "Nm Janitsjar 2018 - 3 Divisjon",
-      "spotify": "https://open.spotify.com/track/0wNWISZO3JbpsP0IwPVEXK",
+      "recording_title": "Between the two Rivers - Variations on Ein Feste Burg",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/4uMjmbmn3wVW03bFfYIdjp",
       "apple_music": "https://music.apple.com/us/album/between-the-two-rivers-variations-on-ein-feste-burg/1369249591?i=1369249729&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "2. divisjon",
+      "band": "Lørenskog Musikkorps",
+      "result_piece": "Tales and Legends",
+      "recording_title": "Tales & Legends",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/6QcZCJ2b465JyEixH4dAWV",
+      "apple_music": "https://music.apple.com/us/album/tales-legends/1369249591?i=1369249597&uo=4"
     },
     {
       "year": 2018,
@@ -268,8 +328,8 @@
       "band": "Os Musikkforening",
       "result_piece": "El Camino Real",
       "recording_title": "El Camino Real",
-      "album": "Nm Janitsjar 2018 - 6 Divisjon",
-      "spotify": "https://open.spotify.com/track/4z0shnBVEhyESPVx8hqtu5",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/1BfYPwfDWUQ1Zt9LhQtBWO",
       "apple_music": "https://music.apple.com/us/album/el-camino-real/1369249591?i=1369249739&uo=4"
     },
     {
@@ -278,8 +338,8 @@
       "band": "Os Musikkforening",
       "result_piece": "Exultate",
       "recording_title": "Exultate",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/1tbGdo0ZcJnJAs4XCw7Sul",
       "apple_music": "https://music.apple.com/us/album/exultate/1369249591?i=1369249737&uo=4"
     },
     {
@@ -288,8 +348,8 @@
       "band": "Os Musikkforening",
       "result_piece": "Lux Aurumque",
       "recording_title": "Lux Arumque",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/3dzDF10pn2Q1DeNdTneFA4",
       "apple_music": "https://music.apple.com/us/album/lux-arumque/1369249591?i=1369249738&uo=4"
     },
     {
@@ -297,9 +357,9 @@
       "division": "2. divisjon",
       "band": "Prosjekt MMXIX",
       "result_piece": "The Planets, 1. sats Mars The Bringer of the War",
-      "recording_title": "The Planets - Jupiter, The bringer of Jollity",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "recording_title": "The Planets - Jupiter, the bringer of Jollity",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/1B5XvG8A6YzhCshkUW7Hnc",
       "apple_music": "https://music.apple.com/us/album/the-planets-jupiter-the-bringer-of-jollity/1369249591?i=1369249734&uo=4"
     },
     {
@@ -307,9 +367,9 @@
       "division": "2. divisjon",
       "band": "Prosjekt MMXIX",
       "result_piece": "The Planets, 4. sats Jupiter The Bringer of Jollity",
-      "recording_title": "The Planets - Jupiter, The bringer of Jollity",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "recording_title": "The Planets - Jupiter, the bringer of Jollity",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/1B5XvG8A6YzhCshkUW7Hnc",
       "apple_music": "https://music.apple.com/us/album/the-planets-jupiter-the-bringer-of-jollity/1369249591?i=1369249734&uo=4"
     },
     {
@@ -317,9 +377,9 @@
       "division": "2. divisjon",
       "band": "Sande Musikkorps",
       "result_piece": "Armenian Dances, Part 1",
-      "recording_title": "Armenian Dances, part 1",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "recording_title": "Armenian Dances, Pt. 1",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/3YDIbLDbsJxp2UGDmkVxKV",
       "apple_music": "https://music.apple.com/us/album/armenian-dances-part-1/1369249591?i=1369249726&uo=4"
     },
     {
@@ -328,8 +388,8 @@
       "band": "Sande Musikkorps",
       "result_piece": "Overture & March \"1776\"",
       "recording_title": "Overture & March \"1776\"",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/7A7ti8PT1Nw6wmH2vxdMaY",
       "apple_music": "https://music.apple.com/us/album/overture-march-1776/1369249591?i=1369249721&uo=4"
     },
     {
@@ -338,8 +398,8 @@
       "band": "Sinsen Konsertorkester",
       "result_piece": "Danceries",
       "recording_title": "Danceries",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/6ADP6SzEdJ9hllywjr5jx2",
       "apple_music": "https://music.apple.com/us/album/danceries/1369249591?i=1369249743&uo=4"
     },
     {
@@ -348,8 +408,8 @@
       "band": "Sinsen Konsertorkester",
       "result_piece": "Overture on Russian and Kirgiz folk themes",
       "recording_title": "Overture on Russian and Kirghiz folk themes",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/6GKDwvmPmkjkseZwLH7ofp",
       "apple_music": "https://music.apple.com/us/album/overture-on-russian-and-kirghiz-folk-themes/1369249591?i=1369249747&uo=4"
     },
     {
@@ -358,8 +418,8 @@
       "band": "Stabekk Janitsjarorkester",
       "result_piece": "Homenaje a Joaquìn Sorolla Cuados Sinfònicos",
       "recording_title": "Homenaje a Joaquin Sorolla",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/2DZyP1HxCnC9ZtyMKKLR2s",
       "apple_music": "https://music.apple.com/us/album/homenaje-a-joaquin-sorolla/1369249591?i=1369249750&uo=4"
     },
     {
@@ -368,9 +428,19 @@
       "band": "Sykkylven Janitsjarorkester",
       "result_piece": "Festival Overture, Op. 39",
       "recording_title": "Festival Overture",
-      "album": "Nm Janitsjar 2018 - 3 Divisjon",
-      "spotify": "https://open.spotify.com/track/0Yx50gQDVbUqlLotmDMkIE",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/5loTIqmQEnmtQQEwk5inSd",
       "apple_music": "https://music.apple.com/us/album/festival-overture/1369249591?i=1369249599&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "2. divisjon",
+      "band": "Sykkylven Janitsjarorkester",
+      "result_piece": "Kokopelli’s Dance",
+      "recording_title": "Kokopelli´s Dance",
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/0EhLYaZeuBu3dtYaAsUAZm",
+      "apple_music": "https://music.apple.com/us/album/kokopellis-dance/1369249591?i=1369249600&uo=4"
     },
     {
       "year": 2018,
@@ -378,8 +448,8 @@
       "band": "Vestsidens Musikkorps",
       "result_piece": "Dances from Crete",
       "recording_title": "Dances from Crete",
-      "album": "NM Janitsjar 2018 - 2 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 2 Divisjon",
+      "spotify": "https://open.spotify.com/track/2Y8UJngYVtphWIcMd2hPhb",
       "apple_music": "https://music.apple.com/us/album/dances-from-crete/1369249591?i=1369249740&uo=4"
     },
     {
@@ -758,8 +828,8 @@
       "band": "Alvdal-Tynset Janitsjarkorps",
       "result_piece": "Prelude, Siciliano and Rondo",
       "recording_title": "Prelude, Siciliano and Rondo",
-      "album": "Nm Janitsjar 2018 - 7 Divisjon",
-      "spotify": "https://open.spotify.com/track/6FSHi0wHPXkzdqmgPd9CfB",
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/5D4i3fhtgHcmmGRu3Ipj23",
       "apple_music": "https://music.apple.com/us/album/prelude-siciliano-and-rondo/1369259321?i=1369259501&uo=4"
     },
     {
@@ -767,9 +837,9 @@
       "division": "5. divisjon",
       "band": "Alvdal-Tynset Janitsjarkorps",
       "result_piece": "With Each Sunset (Comes the Promise of a New Day)",
-      "recording_title": "With Each Sunset",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "recording_title": "With each sunset",
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/6h5WGyhcP4JMfVWB7Q0n9Y",
       "apple_music": "https://music.apple.com/us/album/with-each-sunset/1369259321?i=1369259502&uo=4"
     },
     {
@@ -778,9 +848,29 @@
       "band": "Byåsen Musikkorps",
       "result_piece": "El Camino Real",
       "recording_title": "El Camino Real",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/1u9xCQ8r9nzc2jFkHOvpJv",
       "apple_music": "https://music.apple.com/us/album/el-camino-real/1369259321?i=1369259406&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "5. divisjon",
+      "band": "Bømlo Janitsjar",
+      "result_piece": "Lake of the Moon",
+      "recording_title": "Lake of the Moon",
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/5Wwvdkr3KVTpW54Fne9Ypy",
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon/1369259321?i=1369259405&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "5. divisjon",
+      "band": "Drøbak Musikkorps",
+      "result_piece": "Armenian Dances, Part 1",
+      "recording_title": "Armenske Danser, Del 1",
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/6ny4JjyFnqwlBdmm87NVaL",
+      "apple_music": "https://music.apple.com/us/album/armenian-dances-part-1/1369249591?i=1369249726&uo=4"
     },
     {
       "year": 2018,
@@ -788,8 +878,8 @@
       "band": "Fana Musikklag",
       "result_piece": "Dreamland",
       "recording_title": "Dreamland",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/6ZvCFXkcTmUbameI4tyHv9",
       "apple_music": "https://music.apple.com/us/album/dreamland/1369259321?i=1369259392&uo=4"
     },
     {
@@ -798,8 +888,8 @@
       "band": "Fana Musikklag",
       "result_piece": "Exultate",
       "recording_title": "Exultate",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/3D6x8dCELbwOo84EXdZeiF",
       "apple_music": "https://music.apple.com/us/album/exultate/1369259321?i=1369259395&uo=4"
     },
     {
@@ -808,8 +898,8 @@
       "band": "Haugesund Janitsjarorkester",
       "result_piece": "In Flight",
       "recording_title": "In Flight",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/3nyVQmbBhaP5oYj2IwVbgV",
       "apple_music": "https://music.apple.com/us/album/in-flight/1369259321?i=1369259401&uo=4"
     },
     {
@@ -818,9 +908,19 @@
       "band": "Haugesund Janitsjarorkester",
       "result_piece": "The Hounds of Spring",
       "recording_title": "The Hounds of Spring",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/6JGItTFx8YayAQ7XsdWYZ9",
       "apple_music": "https://music.apple.com/us/album/the-hounds-of-spring/1369259321?i=1369259402&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "5. divisjon",
+      "band": "Jernbanens Musikkorps Oslo",
+      "result_piece": "Lake of the Moon",
+      "recording_title": "Lake of the Moon",
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/0yseDndRJlQ2SMMvgIV8OK",
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon/1369259321?i=1369259396&uo=4"
     },
     {
       "year": 2018,
@@ -828,8 +928,8 @@
       "band": "Musikklaget Kornetten",
       "result_piece": "The Witch and the Saint",
       "recording_title": "The Witch and the Saint",
-      "album": "Nm Janitsjar 2018 - 7 Divisjon",
-      "spotify": "https://open.spotify.com/track/6uc02c7dcgAkGJop6C9XX1",
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/18JJ25eEvGZiW0CmQCozAz",
       "apple_music": "https://music.apple.com/us/album/the-witch-and-the-saint/1369259321?i=1369259398&uo=4"
     },
     {
@@ -838,8 +938,8 @@
       "band": "Nannestad Janitsjarkorps",
       "result_piece": "subTERRA",
       "recording_title": "SubTERRA",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/36WpcGhzbasO1JCEfXVgry",
       "apple_music": "https://music.apple.com/us/album/subterra/1369259321?i=1369259403&uo=4"
     },
     {
@@ -848,8 +948,8 @@
       "band": "Oslo Janitsjarkorps",
       "result_piece": "Ascension",
       "recording_title": "The Ascension",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/2P21ii7zJPlFdwp7oWyNha",
       "apple_music": "https://music.apple.com/us/album/the-ascension/1369259321?i=1369259410&uo=4"
     },
     {
@@ -858,8 +958,8 @@
       "band": "Oslo Janitsjarkorps",
       "result_piece": "The Divine Comedy, 2. sats Purgatorio",
       "recording_title": "Purgatorio",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/2qdXFPIbbqnTUlLuDbQRuo",
       "apple_music": "https://music.apple.com/us/album/purgatorio/1369259321?i=1369259409&uo=4"
     },
     {
@@ -868,8 +968,8 @@
       "band": "Rælingen Musikklag",
       "result_piece": "The Magnetic Mountain",
       "recording_title": "The Magnetic Mountain",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/19dCmVNSJHRCGOqn4UZoId",
       "apple_music": "https://music.apple.com/us/album/the-magnetic-mountain/1369259321?i=1369259400&uo=4"
     },
     {
@@ -878,8 +978,8 @@
       "band": "Strinda Ungdomskorps",
       "result_piece": "Jericho",
       "recording_title": "Jericho",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/6uLgxobWpGL8IrPKHP5A9T",
       "apple_music": "https://music.apple.com/us/album/jericho/1369259321?i=1369259397&uo=4"
     },
     {
@@ -888,9 +988,9 @@
       "band": "Tolga-Os Janitsjar",
       "result_piece": "subTERRA",
       "recording_title": "SubTERRA",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/subterra/1369259321?i=1369259403&uo=4"
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/0L0KxOjugLG1M89NaXayax",
+      "apple_music": "https://music.apple.com/us/album/subterra/1369259321?i=1369259404&uo=4"
     },
     {
       "year": 2018,
@@ -898,8 +998,8 @@
       "band": "Tvedestrand Musikkorps",
       "result_piece": "Yiddish Dances, 1., 2., 4. og 5. sats",
       "recording_title": "Yiddish Dances, sats 1,2,4 og 5",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/5HSTYFDTkgABAl4sV6vGL4",
       "apple_music": "https://music.apple.com/us/album/yiddish-dances-sats-1-2-4-og-5/1369259321?i=1369259407&uo=4"
     },
     {
@@ -908,8 +1008,8 @@
       "band": "Vålerenga Janitsjarkorps",
       "result_piece": "Saga Maligna",
       "recording_title": "Saga Maligna",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/2rk1JqSr36sv5j6bkCvqPy",
       "apple_music": "https://music.apple.com/us/album/saga-maligna/1369259321?i=1369259399&uo=4"
     },
     {
@@ -918,8 +1018,8 @@
       "band": "Åsnes Hornmusikk",
       "result_piece": "The Curse of the Mermaid",
       "recording_title": "The Curse of the Mermaid",
-      "album": "NM Janitsjar 2018 - 5 divisjon",
-      "spotify": null,
+      "album": "Nm Janitsjar 2018 - 5 Divisjon",
+      "spotify": "https://open.spotify.com/track/5b2emYEXh8lnR0bXY2kuBE",
       "apple_music": "https://music.apple.com/us/album/the-curse-of-the-mermaid/1369259321?i=1369259408&uo=4"
     },
     {
@@ -939,8 +1039,28 @@
       "result_piece": "Gulliver's Travels",
       "recording_title": "Gulliver´s Travels",
       "album": "Nm Janitsjar 2018 - 6 Divisjon",
-      "spotify": "https://open.spotify.com/track/0WgTiYhNu9htTRSIirDicE",
-      "apple_music": "https://music.apple.com/us/album/gullivers-travels/1369268596?i=1369268717&uo=4"
+      "spotify": "https://open.spotify.com/track/3SboDdBfSAiSmSiw4NRkWz",
+      "apple_music": "https://music.apple.com/us/album/gullivers-travels/1369268596?i=1369268732&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "6. divisjon",
+      "band": "Hadeland Janitsjar",
+      "result_piece": "Overture to a new Age",
+      "recording_title": "Overture to a New Age",
+      "album": "Nm Janitsjar 2018 - 6 Divisjon",
+      "spotify": "https://open.spotify.com/track/2kAxsFsqI2y6e1IhcL7oKu",
+      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age/1369268596?i=1369268721&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "6. divisjon",
+      "band": "Hamar Musikkorps",
+      "result_piece": "Overture to a new Age",
+      "recording_title": "Overture to a New Age",
+      "album": "Nm Janitsjar 2018 - 6 Divisjon",
+      "spotify": "https://open.spotify.com/track/7LwodwD90CLISSvy3CZ0DR",
+      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age/1369268596?i=1369268739&uo=4"
     },
     {
       "year": 2018,
@@ -971,6 +1091,16 @@
       "album": "Nm Janitsjar 2018 - 6 Divisjon",
       "spotify": "https://open.spotify.com/track/0WgTiYhNu9htTRSIirDicE",
       "apple_music": "https://music.apple.com/us/album/gullivers-travels/1369268596?i=1369268717&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "6. divisjon",
+      "band": "Hønefoss Ungdomskorps",
+      "result_piece": "Mont Blanc",
+      "recording_title": "Mont Blanc - La Voie Royale",
+      "album": "Nm Janitsjar 2018 - 6 Divisjon",
+      "spotify": "https://open.spotify.com/track/6rvdtupkalKPX7xzkzl9t4",
+      "apple_music": "https://music.apple.com/us/album/mont-blanc-la-voie-royale/1369268596?i=1369268741&uo=4"
     },
     {
       "year": 2018,
@@ -1051,6 +1181,16 @@
       "album": "Nm Janitsjar 2018 - 6 Divisjon",
       "spotify": "https://open.spotify.com/track/6GLQs69zpXI6E7O3Y2sspg",
       "apple_music": "https://music.apple.com/us/album/vesuvius/1369268596?i=1369268728&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "6. divisjon",
+      "band": "Musikkorpset TEMPO",
+      "result_piece": "The Witch and the Saint",
+      "recording_title": "The Witch and the Saint",
+      "album": "Nm Janitsjar 2018 - 6 Divisjon",
+      "spotify": "https://open.spotify.com/track/7mKwXgHYFobhLtb9DDvkFS",
+      "apple_music": "https://music.apple.com/us/album/the-witch-and-the-saint/1369268596?i=1369268714&uo=4"
     },
     {
       "year": 2018,
@@ -1161,6 +1301,16 @@
       "album": "Nm Janitsjar 2018 - 7 Divisjon",
       "spotify": "https://open.spotify.com/track/3zayZV4aDWFuXm057nchh9",
       "apple_music": "https://music.apple.com/us/album/concerto-damore/1369288211?i=1369288218&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "7. divisjon",
+      "band": "Flatåsen Musikkorps",
+      "result_piece": "Edenstrand",
+      "recording_title": "Edenstrand",
+      "album": "Nm Janitsjar 2018 - 7 Divisjon",
+      "spotify": "https://open.spotify.com/track/4bZNGeSKpjRehRtxnEqhOQ",
+      "apple_music": "https://music.apple.com/us/album/edenstrand/1369288211?i=1369288219&uo=4"
     },
     {
       "year": 2018,
@@ -1336,11 +1486,21 @@
       "year": 2018,
       "division": "7. divisjon",
       "band": "Østerdal Prosjektkorps",
+      "result_piece": "Concert Prelude",
+      "recording_title": "Concert Prelude",
+      "album": "Nm Janitsjar 2018 - 7 Divisjon",
+      "spotify": "https://open.spotify.com/track/72UkHgT0w3t4EPgioFmCyY",
+      "apple_music": "https://music.apple.com/us/album/concert-prelude/1369288211?i=1369288305&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "7. divisjon",
+      "band": "Østerdal Prosjektkorps",
       "result_piece": "Gulliver's Travels",
       "recording_title": "Gulliver´s Travels",
       "album": "Nm Janitsjar 2018 - 7 Divisjon",
-      "spotify": "https://open.spotify.com/track/1dCJyRXADiR19vGw5mmtvx",
-      "apple_music": "https://music.apple.com/us/album/gullivers-travels/1369288211?i=1369288240&uo=4"
+      "spotify": "https://open.spotify.com/track/0GHCsXbIgwOi0gSwTINo0S",
+      "apple_music": "https://music.apple.com/us/album/gullivers-travels/1369288211?i=1369288306&uo=4"
     },
     {
       "year": 2018,
@@ -1361,6 +1521,16 @@
       "album": "Nm Janitsjar 2018 - Elitedivisjon",
       "spotify": "https://open.spotify.com/track/5rfakSZvEGouCn88WmueMU",
       "apple_music": "https://music.apple.com/us/album/short-ride-in-a-fast-machine/1369246521?i=1369246903&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "Stabsarabesk",
+      "recording_title": "Stabsarabesk",
+      "album": "Nm Janitsjar 2018 - Elitedivisjon",
+      "spotify": "https://open.spotify.com/track/6vGkULM10yzmlEwhbmhyCo",
+      "apple_music": "https://music.apple.com/us/album/stabsarabesk/1369246521?i=1369246906&uo=4"
     },
     {
       "year": 2018,
@@ -1395,6 +1565,16 @@
     {
       "year": 2018,
       "division": "Elite",
+      "band": "Lillestrøm Musikkorps",
+      "result_piece": "Symphony no. 4",
+      "recording_title": "Symphony No. 4",
+      "album": "Nm Janitsjar 2018 - Elitedivisjon",
+      "spotify": "https://open.spotify.com/track/0OSmaJdxkqe2Fmd5laM2O2",
+      "apple_music": "https://music.apple.com/us/album/symphony-no-4/1369246521?i=1369246902&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "Elite",
       "band": "Mo Hornmusikk",
       "result_piece": "Danza de los Duendes",
       "recording_title": "Danza de los Duendes",
@@ -1416,6 +1596,16 @@
       "year": 2018,
       "division": "Elite",
       "band": "Musikkforeningen Nidarholm",
+      "result_piece": "Bachseits",
+      "recording_title": "Bachseits",
+      "album": "Nm Janitsjar 2018 - Elitedivisjon",
+      "spotify": "https://open.spotify.com/track/4kyDXxiqNlTAO3ZSfko6Lu",
+      "apple_music": "https://music.apple.com/us/album/bachseits/1369246521?i=1369246901&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "Elite",
+      "band": "Musikkforeningen Nidarholm",
       "result_piece": "Symphony no. 1 for Wind Band: Solitude Standing",
       "recording_title": "Symphony no. 1 for wind band - Solitude Standing",
       "album": "Nm Janitsjar 2018 - Elitedivisjon",
@@ -1431,6 +1621,26 @@
       "album": "Nm Janitsjar 2018 - Elitedivisjon",
       "spotify": "https://open.spotify.com/track/4OnmODJ4wPPWJF0Axh9k0T",
       "apple_music": "https://music.apple.com/us/album/fantasy-variations/1369246521?i=1369246899&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "Elite",
+      "band": "Opus 82",
+      "result_piece": "Traveler",
+      "recording_title": "Traveler",
+      "album": "Nm Janitsjar 2018 - Elitedivisjon",
+      "spotify": "https://open.spotify.com/track/5A21dITYlcpx2Zjn5x3vvc",
+      "apple_music": "https://music.apple.com/us/album/traveler/1369246521?i=1369246898&uo=4"
+    },
+    {
+      "year": 2018,
+      "division": "Elite",
+      "band": "Sarpsborg Janitsjarkorps",
+      "result_piece": "Changes",
+      "recording_title": "Changes for Symphonic Wind Band",
+      "album": "Nm Janitsjar 2018 - Elitedivisjon",
+      "spotify": "https://open.spotify.com/track/3LijeEXdtpxisOQnFIdnKk",
+      "apple_music": "https://music.apple.com/us/album/changes-for-symphonic-wind-band/1369246521?i=1369246908&uo=4"
     },
     {
       "year": 2018,

--- a/apps/band-positions/public/data/streaming/wind/2019.json
+++ b/apps/band-positions/public/data/streaming/wind/2019.json
@@ -648,8 +648,8 @@
       "band": "Arendal Byorkester",
       "result_piece": "Noah’s Ark",
       "recording_title": "Noah´s Ark",
-      "album": "NM Janitsjar 2019 - 7 divisjon",
-      "spotify": "https://open.spotify.com/track/76GvvjlVoYFImnKAn53yqI",
+      "album": "NM Janitsjar 2019 - 4 divisjon",
+      "spotify": "https://open.spotify.com/track/140oUbH3Q6ZK5TZItqsri2",
       "apple_music": "https://music.apple.com/us/album/noahs-ark/1460693460?i=1460693471&uo=4"
     },
     {
@@ -659,7 +659,7 @@
       "result_piece": "Goddess of Fire",
       "recording_title": "Goddess of Fire",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/0QW545OmrTbiot8db9Wzki",
       "apple_music": "https://music.apple.com/us/album/goddess-of-fire/1460693460?i=1460694004&uo=4"
     },
     {
@@ -669,17 +669,17 @@
       "result_piece": "Rush",
       "recording_title": "Rush",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/rush/1460693460?i=1460693730&uo=4"
+      "spotify": "https://open.spotify.com/track/5D5d8m7VV7ipS8MdFThTZ5",
+      "apple_music": "https://music.apple.com/us/album/rush/1460693460?i=1460694009&uo=4"
     },
     {
       "year": 2019,
       "division": "4. divisjon",
       "band": "Bodø Harmonimusikk",
       "result_piece": "Angels in the Architecture",
-      "recording_title": "Angels in Architecture",
-      "album": "NM Janitsjar 2019 - 6 divisjon",
-      "spotify": "https://open.spotify.com/track/6QkShd68GtKno2V0jcqLf0",
+      "recording_title": "Angels in the Architecture",
+      "album": "NM Janitsjar 2019 - 4 divisjon",
+      "spotify": "https://open.spotify.com/track/5Oj4d8fZE6KO3sDxOeYbgY",
       "apple_music": "https://music.apple.com/us/album/angels-in-the-architecture/1460693460?i=1460693569&uo=4"
     },
     {
@@ -689,7 +689,7 @@
       "result_piece": "Eine Kleine Yiddishe Ragmusik",
       "recording_title": "Eine Kleine Yiddishe Ragmusik",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/5dUQMWzH7Kxn1UkSeJX7Y8",
       "apple_music": "https://music.apple.com/us/album/eine-kleine-yiddishe-ragmusik/1460693460?i=1460693914&uo=4"
     },
     {
@@ -699,7 +699,7 @@
       "result_piece": "The Hounds of Spring",
       "recording_title": "The Hounds of Spring",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6IqSGB0676A3QRoEHQCfog",
       "apple_music": "https://music.apple.com/us/album/the-hounds-of-spring/1460693460?i=1460693925&uo=4"
     },
     {
@@ -709,7 +709,7 @@
       "result_piece": "Lake of the Moon",
       "recording_title": "Lake of the Moon",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4AIIM66iadETV8RhmStetJ",
       "apple_music": "https://music.apple.com/us/album/lake-of-the-moon/1460693460?i=1460694002&uo=4"
     },
     {
@@ -719,7 +719,7 @@
       "result_piece": "Between the Two Rivers",
       "recording_title": "Between the Two Rivers",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/12lcKq6PBMm5QID1oLI9Ji",
       "apple_music": "https://music.apple.com/us/album/between-the-two-rivers/1460693460?i=1460694000&uo=4"
     },
     {
@@ -728,8 +728,8 @@
       "band": "Haugesund Janitsjarorkester",
       "result_piece": "El Camino Real",
       "recording_title": "El Camino Real",
-      "album": "NM Janitsjar 2019 - 7 divisjon",
-      "spotify": "https://open.spotify.com/track/487VeYM3aLq8QCeduUN89I",
+      "album": "NM Janitsjar 2019 - 4 divisjon",
+      "spotify": "https://open.spotify.com/track/0CC2MgrmNZ2D6NIvKMtmxn",
       "apple_music": "https://music.apple.com/us/album/el-camino-real/1460693460?i=1460693742&uo=4"
     },
     {
@@ -739,7 +739,7 @@
       "result_piece": "Rush",
       "recording_title": "Rush",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4dfpYidDrFtMrXibL3eRsj",
       "apple_music": "https://music.apple.com/us/album/rush/1460693460?i=1460693730&uo=4"
     },
     {
@@ -747,9 +747,9 @@
       "division": "4. divisjon",
       "band": "Musikkforeningen Viken",
       "result_piece": "Gulliver's Travels",
-      "recording_title": "Gulliver's Travels",
+      "recording_title": "Gulliver´s Travels",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/7csh62xPN8d6MOlmJvdgDv",
       "apple_music": "https://music.apple.com/us/album/gullivers-travels/1460693460?i=1460693474&uo=4"
     },
     {
@@ -759,7 +759,7 @@
       "result_piece": "Sea Songs",
       "recording_title": "Sea songs",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/7wsPyEXdOKsvNn4gjKTAba",
       "apple_music": "https://music.apple.com/us/album/sea-songs/1460693460?i=1460693478&uo=4"
     },
     {
@@ -769,7 +769,7 @@
       "result_piece": "The Land of the Long White Cloud",
       "recording_title": "The Land of the Long White Cloud",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/1aXdSVk9Mav0B1Z2PJnt18",
       "apple_music": "https://music.apple.com/us/album/the-land-of-the-long-white-cloud/1460693460?i=1460693744&uo=4"
     },
     {
@@ -778,9 +778,9 @@
       "band": "Oppegård Janitsjar",
       "result_piece": "Hispanola",
       "recording_title": "Hipaniola",
-      "album": "NM Janitsjar 2019 - 6 divisjon",
-      "spotify": "https://open.spotify.com/track/7jZRfKQLyXt4ATjOhti1lR",
-      "apple_music": "https://music.apple.com/us/album/hipaniola/1460190452?i=1460190704&uo=4"
+      "album": "NM Janitsjar 2019 - 4 divisjon",
+      "spotify": "https://open.spotify.com/track/1vzK6Fh5rt1fBF7L9EMrHI",
+      "apple_music": "https://music.apple.com/us/album/hipaniola/1460693460?i=1460693554&uo=4"
     },
     {
       "year": 2019,
@@ -789,7 +789,7 @@
       "result_piece": "A Moorside suite, 3. sats March",
       "recording_title": "A Moorside Suite - 3 sats, March",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/0YBMZFM2LpT48sNCF7U4dm",
       "apple_music": "https://music.apple.com/us/album/a-moorside-suite-3-sats-march/1460693460?i=1460693548&uo=4"
     },
     {
@@ -799,7 +799,7 @@
       "result_piece": "Sacred Harp",
       "recording_title": "Sacred Harp",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/42YmR6cPqSKxKHDHhgSuvZ",
       "apple_music": "https://music.apple.com/us/album/sacred-harp/1460693460?i=1460693553&uo=4"
     },
     {
@@ -808,9 +808,9 @@
       "band": "Ringsaker Janitjsar",
       "result_piece": "Machu Picchu - City in the sky - the mystery of the hidden sun Temple",
       "recording_title": "Machu Picchu",
-      "album": "NM Janitsjar 2019 - 6 divisjon",
-      "spotify": "https://open.spotify.com/track/5n3WllGdGHV4lEJa2oduGI",
-      "apple_music": "https://music.apple.com/us/album/machu-picchu/1460190452?i=1460190474&uo=4"
+      "album": "NM Janitsjar 2019 - 4 divisjon",
+      "spotify": "https://open.spotify.com/track/3ZcXRYRfTt3UZX3ZehQMSS",
+      "apple_music": "https://music.apple.com/us/album/machu-picchu/1460693460?i=1460693566&uo=4"
     },
     {
       "year": 2019,
@@ -819,7 +819,7 @@
       "result_piece": "Of Ancient Dances",
       "recording_title": "Of Ancient Dances",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4AwPkINdwpFHf6cMLfTb86",
       "apple_music": "https://music.apple.com/us/album/of-ancient-dances/1460693460?i=1460693997&uo=4"
     },
     {
@@ -828,9 +828,9 @@
       "band": "Sofienberg Musikkorps",
       "result_piece": "Machu Picchu - City in the sky - the mystery of the hidden sun Temple",
       "recording_title": "Machu Picchu",
-      "album": "NM Janitsjar 2019 - 6 divisjon",
-      "spotify": "https://open.spotify.com/track/5n3WllGdGHV4lEJa2oduGI",
-      "apple_music": "https://music.apple.com/us/album/machu-picchu/1460190452?i=1460190474&uo=4"
+      "album": "NM Janitsjar 2019 - 4 divisjon",
+      "spotify": "https://open.spotify.com/track/1K3gAE8NXf0mHwm5Cxk4Xw",
+      "apple_music": "https://music.apple.com/us/album/machu-picchu/1460693460?i=1460693558&uo=4"
     },
     {
       "year": 2019,
@@ -839,7 +839,7 @@
       "result_piece": "subTERRA",
       "recording_title": "subTERRA",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/57mPK8pvb2zkvuhQJYw8AJ",
       "apple_music": "https://music.apple.com/us/album/subterra/1460693460?i=1460693562&uo=4"
     },
     {
@@ -849,7 +849,7 @@
       "result_piece": "Time for Outrage!",
       "recording_title": "Time for Outrage !",
       "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/5yEI11Tw84vvXUhHtKx8HK",
       "apple_music": "https://music.apple.com/us/album/time-for-outrage/1460693460?i=1460693931&uo=4"
     },
     {
@@ -857,30 +857,110 @@
       "division": "5. divisjon",
       "band": "Alvdal-Tynset Janitsjarkorps",
       "result_piece": "Goddess of Fire",
-      "recording_title": "Goddess of Fire",
-      "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/goddess-of-fire/1460693460?i=1460694004&uo=4"
+      "recording_title": "Goddess of fire",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/3oW8p6bRs2ypFIdCO4YEMf",
+      "apple_music": "https://music.apple.com/us/album/goddess-of-fire/1460701955?i=1460702075&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Alvdal-Tynset Janitsjarkorps",
+      "result_piece": "Take Off",
+      "recording_title": "Take Off",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/4mGdpEtnaErSZ5zayb5OpY",
+      "apple_music": "https://music.apple.com/us/album/take-off/1460701955?i=1460701971&uo=4"
     },
     {
       "year": 2019,
       "division": "5. divisjon",
       "band": "Bømlo Janitsjar",
       "result_piece": "Saga Maligna",
-      "recording_title": "Saga Candida",
-      "album": "NM Janitsjar 2019 - 2 divisjon",
-      "spotify": "https://open.spotify.com/track/3VpsF6P5L5jEDisb4owXCI",
-      "apple_music": "https://music.apple.com/us/album/saga-candida/1460683954?i=1460685103&uo=4"
+      "recording_title": "Saga Maligna",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/4ExCmsMej78OIfBxTlb6Z5",
+      "apple_music": "https://music.apple.com/us/album/saga-maligna/1460701955?i=1460702654&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Fana Musikklag",
+      "result_piece": "Deliverance",
+      "recording_title": "Deliverance",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/1B5bPD8nmY3XobDxNDHDn2",
+      "apple_music": "https://music.apple.com/us/album/deliverance/1460701955?i=1460702575&uo=4"
     },
     {
       "year": 2019,
       "division": "5. divisjon",
       "band": "Hamar Musikkorps",
       "result_piece": "Mont Blanc",
-      "recording_title": "Mont-Blanc La voie Royale",
-      "album": "NM Janitsjar 2019 - 6 divisjon",
-      "spotify": "https://open.spotify.com/track/3Hkr1sBWG3WJdzKLDtMJGO",
-      "apple_music": "https://music.apple.com/us/album/mont-blanc-la-voie-royale/1460190452?i=1460190778&uo=4"
+      "recording_title": "Mont-Blanc",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/69nTp1psIIyfg3Ah9I1Naj",
+      "apple_music": "https://music.apple.com/us/album/mont-blanc/1460701955?i=1460702642&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Heimdal Musikkorps",
+      "result_piece": "Slava!",
+      "recording_title": "Slava!",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/30APweHMzAhcT6YFvz1Guk",
+      "apple_music": "https://music.apple.com/us/album/slava/1460701955?i=1460703149&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Heimdal Musikkorps",
+      "result_piece": "Songs of Sailor and Sea",
+      "recording_title": "Song of Sailor and Sea",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/4JWAW1Fj3o3YluC0H4lWfD",
+      "apple_music": "https://music.apple.com/us/album/song-of-sailor-and-sea/1460701955?i=1460703167&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Jernbanens Musikkorps Oslo",
+      "result_piece": "The Junction Point",
+      "recording_title": "The Junction Point",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/6V1wsbSpckjPZhL6qYqG7V",
+      "apple_music": "https://music.apple.com/us/album/the-junction-point/1460701955?i=1460702965&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Melhus Janitsjarkorps",
+      "result_piece": "Flying the Breeze",
+      "recording_title": "Flying the Breeze",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/738IMEsfhwpBXuQyGStbpg",
+      "apple_music": "https://music.apple.com/us/album/flying-the-breeze/1460701955?i=1460702869&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Melhus Janitsjarkorps",
+      "result_piece": "Tales and Myths of Gothia",
+      "recording_title": "Tales and Myths of Gothia",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/6QfhcuQtr7rSi35aIbsB7d",
+      "apple_music": "https://music.apple.com/us/album/tales-and-myths-of-gothia/1460701955?i=1460702853&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Mjøsen Janitsjar",
+      "result_piece": "Chorale and Variations",
+      "recording_title": "Chorale and Variations",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/7IRaLdpF5VZ454ZT2Tmo3n",
+      "apple_music": "https://music.apple.com/us/album/chorale-and-variations/1460701955?i=1460702282&uo=4"
     },
     {
       "year": 2019,
@@ -888,9 +968,9 @@
       "band": "Musikklaget Kornetten",
       "result_piece": "Noah’s Ark",
       "recording_title": "Noah´s Ark",
-      "album": "NM Janitsjar 2019 - 7 divisjon",
-      "spotify": "https://open.spotify.com/track/76GvvjlVoYFImnKAn53yqI",
-      "apple_music": "https://music.apple.com/us/album/noahs-ark/1460693460?i=1460693471&uo=4"
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/0LhIMbVLAQVZHGeDuXPOph",
+      "apple_music": "https://music.apple.com/us/album/noahs-ark/1460701955?i=1460702085&uo=4"
     },
     {
       "year": 2019,
@@ -898,9 +978,29 @@
       "band": "Musikklaget Ustemt",
       "result_piece": "El Camino Real",
       "recording_title": "El Camino Real",
-      "album": "NM Janitsjar 2019 - 7 divisjon",
-      "spotify": "https://open.spotify.com/track/487VeYM3aLq8QCeduUN89I",
-      "apple_music": "https://music.apple.com/us/album/el-camino-real/1460693460?i=1460693742&uo=4"
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/69EyE0tsvsxGRsrWGVefTX",
+      "apple_music": "https://music.apple.com/us/album/el-camino-real/1460701955?i=1460702950&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Musikklaget Ustemt",
+      "result_piece": "Landscapes",
+      "recording_title": "Landscapes",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/7affNcsVVTzGhmmgdmHzV1",
+      "apple_music": "https://music.apple.com/us/album/landscapes/1460701955?i=1460702873&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Odda Musikklag",
+      "result_piece": "Lebuinus ex Daventria",
+      "recording_title": "Lebuins ex Daventria",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/7MNdpBvZyneM106joWWgVa",
+      "apple_music": "https://music.apple.com/us/album/lebuins-ex-daventria/1460701955?i=1460702358&uo=4"
     },
     {
       "year": 2019,
@@ -908,9 +1008,29 @@
       "band": "Rælingen Musikklag",
       "result_piece": "Pilatus: Mountain of Dragons",
       "recording_title": "Pilatus: Mountain of Dragons",
-      "album": "NM Janitsjar 2019 - 6 divisjon",
-      "spotify": "https://open.spotify.com/track/5lkZZNAFDOyMgxFPPCWY7z",
-      "apple_music": "https://music.apple.com/us/album/pilatus-mountain-of-dragons/1460190452?i=1460190854&uo=4"
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/4xYGj7rVZC4YzCn1zfkVz1",
+      "apple_music": "https://music.apple.com/us/album/pilatus-mountain-of-dragons/1460701955?i=1460702095&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Tolga-Os Janitsjar",
+      "result_piece": "Hymn to the Sun",
+      "recording_title": "Hymn to the Sun-With the Beat of Mother Earth",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/5xanoVNgyUQ0DSqt2CJaU1",
+      "apple_music": "https://music.apple.com/us/album/hymn-to-the-sun-with-the-beat-of-mother-earth/1460701955?i=1460702960&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Tvedestrand Musikkorps",
+      "result_piece": "Isles of the Blessed",
+      "recording_title": "Isles of the Blessed",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/4pI8Tys7ZUhkqrXlHdViFa",
+      "apple_music": "https://music.apple.com/us/album/isles-of-the-blessed/1460701955?i=1460702462&uo=4"
     },
     {
       "year": 2019,
@@ -918,9 +1038,19 @@
       "band": "Ås og Vestby Musikkorps",
       "result_piece": "subTERRA",
       "recording_title": "subTERRA",
-      "album": "NM Janitsjar 2019 - 4 divisjon",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/subterra/1460693460?i=1460693562&uo=4"
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/4LBu6BmnvNaKpisTDeuGiu",
+      "apple_music": "https://music.apple.com/us/album/subterra/1460701955?i=1460702339&uo=4"
+    },
+    {
+      "year": 2019,
+      "division": "5. divisjon",
+      "band": "Åsnes Hornmusikk",
+      "result_piece": "Tower of Babel",
+      "recording_title": "Tower of Babel",
+      "album": "NM Janitsjar 2019 - 5 divisjon",
+      "spotify": "https://open.spotify.com/track/3bsKKRRH84xLwcveNbl9w7",
+      "apple_music": "https://music.apple.com/us/album/tower-of-babel/1460701955?i=1460702547&uo=4"
     },
     {
       "year": 2019,
@@ -1170,7 +1300,7 @@
       "recording_title": "Edenstrand",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/7AFseW0cwDho3ZSHgtwEfG",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/edenstrand/1460045964?i=1460046287&uo=4"
     },
     {
       "year": 2019,
@@ -1179,8 +1309,8 @@
       "result_piece": "El Camino Real",
       "recording_title": "El Camino Real",
       "album": "NM Janitsjar 2019 - 7 divisjon",
-      "spotify": "https://open.spotify.com/track/487VeYM3aLq8QCeduUN89I",
-      "apple_music": "https://music.apple.com/us/album/el-camino-real/1460693460?i=1460693742&uo=4"
+      "spotify": "https://open.spotify.com/track/7mdleiIM75pitE6dWN35Nu",
+      "apple_music": "https://music.apple.com/us/album/el-camino-real/1460045964?i=1460046288&uo=4"
     },
     {
       "year": 2019,
@@ -1190,7 +1320,7 @@
       "recording_title": "Storbystev",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/7Dw7bhSLVku6FdsGLuDFAH",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/storbystev/1460045964?i=1460046281&uo=4"
     },
     {
       "year": 2019,
@@ -1200,7 +1330,7 @@
       "recording_title": "Einstein",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/5PENLN4GW0mCYRd0lcKfrE",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/einstein/1460045964?i=1460046419&uo=4"
     },
     {
       "year": 2019,
@@ -1210,7 +1340,7 @@
       "recording_title": "Utopia",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/5B9aetrdVRre0pFL0hR3l2",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/utopia/1460045964?i=1460046116&uo=4"
     },
     {
       "year": 2019,
@@ -1220,7 +1350,7 @@
       "recording_title": "Life in the Capital City",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/08EA8J8AV7fst2F9CTGl0y",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/life-in-the-capital-city/1460045964?i=1460046273&uo=4"
     },
     {
       "year": 2019,
@@ -1230,7 +1360,7 @@
       "recording_title": "Music for a Festival",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/5InsgtTYc8UPo1v8eqqR3n",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/music-for-a-festival/1460045964?i=1460046278&uo=4"
     },
     {
       "year": 2019,
@@ -1240,7 +1370,7 @@
       "recording_title": "Iberian Escapedes",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/3fA4sa7Iy8VPwWKniIIsP4",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/iberian-escapedes/1460045964?i=1460046293&uo=4"
     },
     {
       "year": 2019,
@@ -1250,7 +1380,7 @@
       "recording_title": "Sinfonia Noblissima",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/0ztYuDsYOy8RFFwxGBhU1a",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/sinfonia-noblissima/1460045964?i=1460046289&uo=4"
     },
     {
       "year": 2019,
@@ -1260,7 +1390,7 @@
       "recording_title": "Oregon",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/1gSbHg8sBRK96Ns93BUNhK",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/oregon/1460045964?i=1460046434&uo=4"
     },
     {
       "year": 2019,
@@ -1270,7 +1400,7 @@
       "recording_title": "Puszta",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/0kbcRI8oKncfKNF3oRbVxB",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/puszta/1460045964?i=1460046430&uo=4"
     },
     {
       "year": 2019,
@@ -1280,7 +1410,7 @@
       "recording_title": "Blues Mambo",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/775JgqafpCKBoKQk8bmteq",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/blues-mambo/1460045964?i=1460046269&uo=4"
     },
     {
       "year": 2019,
@@ -1290,7 +1420,7 @@
       "recording_title": "Where the River flows - A Historical Triology",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/1v40zLpppDuBkcUB0QtxPJ",
-      "apple_music": "https://music.apple.com/us/album/between-the-two-rivers/1460693460?i=1460694000&uo=4"
+      "apple_music": "https://music.apple.com/us/album/where-the-river-flows-a-historical-triology/1460045964?i=1460046145&uo=4"
     },
     {
       "year": 2019,
@@ -1300,7 +1430,7 @@
       "recording_title": "El Camino Real",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/487VeYM3aLq8QCeduUN89I",
-      "apple_music": "https://music.apple.com/us/album/el-camino-real/1460693460?i=1460693742&uo=4"
+      "apple_music": "https://music.apple.com/us/album/el-camino-real/1460045964?i=1460046144&uo=4"
     },
     {
       "year": 2019,
@@ -1310,7 +1440,7 @@
       "recording_title": "Into the Raging River",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/1Li5RxuN5CSAmkGTsbC8EH",
-      "apple_music": "https://music.apple.com/us/album/into-the-raging-river/1460190452?i=1460190693&uo=4"
+      "apple_music": "https://music.apple.com/us/album/into-the-raging-river/1460045964?i=1460046138&uo=4"
     },
     {
       "year": 2019,
@@ -1320,7 +1450,7 @@
       "recording_title": "Williambyrd Suite (1,3,4 og 6 sats)",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/0Tykh2qY2CG2Q7W6S5CTE2",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/williambyrd-suite-1-3-4-og-6-sats/1460045964?i=1460046423&uo=4"
     },
     {
       "year": 2019,
@@ -1330,7 +1460,7 @@
       "recording_title": "Jupiter Hymn",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/4T07uIJrXljNicSa9VNHAs",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/jupiter-hymn/1460045964?i=1460046121&uo=4"
     },
     {
       "year": 2019,
@@ -1340,7 +1470,7 @@
       "recording_title": "Noah´s Ark",
       "album": "NM Janitsjar 2019 - 7 divisjon",
       "spotify": "https://open.spotify.com/track/76GvvjlVoYFImnKAn53yqI",
-      "apple_music": "https://music.apple.com/us/album/noahs-ark/1460693460?i=1460693471&uo=4"
+      "apple_music": "https://music.apple.com/us/album/noahs-ark/1460045964?i=1460046137&uo=4"
     },
     {
       "year": 2019,

--- a/apps/band-positions/public/data/streaming/wind/2022.json
+++ b/apps/band-positions/public/data/streaming/wind/2022.json
@@ -7,39 +7,79 @@
       "division": "1. divisjon",
       "band": "Alvøens Musikkforening",
       "result_piece": "Pinocchio",
-      "recording_title": "Pinocchio (Complete Ed.) Symphonic Suite (Live)",
+      "recording_title": "Pinocchio (Complete Ed.) Symphonic Suite - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/10qqn91tSiqSCNM8q00as4",
       "apple_music": "https://music.apple.com/us/album/pinocchio-complete-ed-symphonic-suite-live/1621096649?i=1621097059&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "1. divisjon",
+      "band": "Asker Musikkorps",
+      "result_piece": "Homenaje a Joaquìn Sorolla Cuados Sinfònicos",
+      "recording_title": "Homenaje a Joaquín SorollaHomenaje a Joaquín Sorolla - Live",
+      "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4qb9lyFSvEP38MvEnowMQn",
+      "apple_music": "https://music.apple.com/us/album/homenaje-a-joaqu%C3%ADn-sorollahomenaje-a-joaqu%C3%ADn-sorolla-live/1621096649?i=1621096650&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "1. divisjon",
+      "band": "Borge Musikkorps",
+      "result_piece": "Symphony in B flat for Concert Band",
+      "recording_title": "Symphony in B-Flat for Band: I. Moderately fast - II. Andantino grazioso - III. Fugue. - Live",
+      "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3ak4zi8BB9ycpfSU8GK8a8",
+      "apple_music": "https://music.apple.com/us/album/symphony-in-b-flat-for-band-i-moderately-fast-ii-andantino/1621096649?i=1621096654&uo=4"
     },
     {
       "year": 2022,
       "division": "1. divisjon",
       "band": "Byneset Musikkorps",
       "result_piece": "Machu Picchu - City in the sky - the mystery of the hidden sun Temple",
-      "recording_title": "Machu Picchu - City in the Sky The Mystery of the Hidden Sun Temple (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/machu-picchu-city-in-the-sky-the-mystery-of/1621078172?i=1621078887&uo=4"
+      "recording_title": "Machu Picchu - City in the Sky The Mystery of the Hidden Sun Temple - Live",
+      "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4Tm0hZzh61HdcWO4uoev3y",
+      "apple_music": "https://music.apple.com/us/album/machu-picchu-city-in-the-sky-the-mystery-of/1621096649?i=1621097314&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "1. divisjon",
+      "band": "Byneset Musikkorps",
+      "result_piece": "Spiritual Planet, 1. og 2. sats",
+      "recording_title": "Spiritual planet: I. Lost Souls - II. Enlightenment - Live",
+      "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/21yv28Ysy29di2m6YAxdvH",
+      "apple_music": "https://music.apple.com/us/album/spiritual-planet-i-lost-souls-ii-enlightenment-live/1621096649?i=1621097303&uo=4"
     },
     {
       "year": 2022,
       "division": "1. divisjon",
       "band": "Nittedal og Hakadal Janitsjar",
       "result_piece": "Selamlik, Op. 48",
-      "recording_title": "Sélamlik, Op. 48 - No. 1 (Live)",
+      "recording_title": "Sélamlik, Op. 48 - No. 1 - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/50jV8TseUGctBabVjGaSqr",
       "apple_music": "https://music.apple.com/us/album/s%C3%A9lamlik-op-48-no-1-live/1621096649?i=1621097048&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "1. divisjon",
+      "band": "Nittedal og Hakadal Janitsjar",
+      "result_piece": "Symphony no. 6",
+      "recording_title": "Sélamlik, Op. 48 - No. 1 - Live",
+      "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/50jV8TseUGctBabVjGaSqr",
+      "apple_music": null
     },
     {
       "year": 2022,
       "division": "1. divisjon",
       "band": "Os Musikkforening",
       "result_piece": "Incantation and Dance",
-      "recording_title": "Incantation and Dance (Live)",
+      "recording_title": "Incantation and Dance - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6NZmieVYlwFfDn9LvFNSRc",
       "apple_music": "https://music.apple.com/us/album/incantation-and-dance-live/1621096649?i=1621097068&uo=4"
     },
     {
@@ -47,9 +87,9 @@
       "division": "1. divisjon",
       "band": "Os Musikkforening",
       "result_piece": "Polovetsian Dances from Prince Igor",
-      "recording_title": "Polovtsian Dances from Opera \"Prince Igor\" (Live)",
+      "recording_title": "Polovtsian Dances from Opera \"Prince Igor\" - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/0nT8mHcsFNyarcx49TYfq0",
       "apple_music": "https://music.apple.com/us/album/polovtsian-dances-from-opera-prince-igor-live/1621096649?i=1621097073&uo=4"
     },
     {
@@ -57,9 +97,9 @@
       "division": "1. divisjon",
       "band": "Os Musikkforening",
       "result_piece": "Underlige Aftenlufte",
-      "recording_title": "Underlige aftenlufte (Carl Nielsen) [Live]",
+      "recording_title": "Underlige aftenlufte (Carl Nielsen) - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4oB25hVA0IS1ddJbYtC1g0",
       "apple_music": "https://music.apple.com/us/album/underlige-aftenlufte-carl-nielsen-live/1621096649?i=1621097069&uo=4"
     },
     {
@@ -67,9 +107,9 @@
       "division": "1. divisjon",
       "band": "Sandefjord Musikkorps",
       "result_piece": "Equus",
-      "recording_title": "Equus - Live",
-      "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/0CKorKD0PwO9OG2PhkNAHf",
+      "recording_title": "Equus - concert band - Live",
+      "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6kmNWud20Q0wN8lfIUdZvt",
       "apple_music": "https://music.apple.com/us/album/equus-concert-band-live/1621096649?i=1621097440&uo=4"
     },
     {
@@ -77,9 +117,9 @@
       "division": "1. divisjon",
       "band": "Sandefjord Musikkorps",
       "result_piece": "Festival Overture, Op. 39",
-      "recording_title": "Festival Overture, Op. 39 (Live)",
+      "recording_title": "Festival Overture, Op. 39 - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/1j9BlDrf6IR8wbnBzxm0di",
       "apple_music": "https://music.apple.com/us/album/festival-overture-op-39-live/1621096649?i=1621097439&uo=4"
     },
     {
@@ -87,20 +127,60 @@
       "division": "1. divisjon",
       "band": "Sarpsborg Janitsjarkorps",
       "result_piece": "Dance Movements",
-      "recording_title": "Dance Movements (Live)",
+      "recording_title": "Dance Movements - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4XM6beIMUfglr3T6MVo3VT",
       "apple_music": "https://music.apple.com/us/album/dance-movements-live/1621096649?i=1621097299&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "1. divisjon",
+      "band": "Skjold Nesttun Janitsjar",
+      "result_piece": "Peter Pan",
+      "recording_title": "Peter Pan: I. The Open Window. The Shadow. We Fly - II. Neverland - III. El Hogar Feliz. El cuento de Wendy - IV. The Redskins. The Kidnapping of the Children. - Live",
+      "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/61qw61VPtu91uLyyHLMNhF",
+      "apple_music": "https://music.apple.com/us/album/peter-pan-i-the-open-window-the-shadow-we-fly/1621096649?i=1621097287&uo=4"
     },
     {
       "year": 2022,
       "division": "1. divisjon",
       "band": "Stavanger Musikkorps av 1919",
       "result_piece": "Zenith of the Maya",
-      "recording_title": "Zenith of the Maya (Live)",
+      "recording_title": "Zenith of the Maya - Live",
       "album": "Nm Janitsjar 2022 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/2FeWqUvJt7Y2UFKu3AAvPB",
       "apple_music": "https://music.apple.com/us/album/zenith-of-the-maya-live/1621096649?i=1621097451&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Bispehaugen Ungdomskorps",
+      "result_piece": "Tales and Legends, 1. og 3. sats",
+      "recording_title": "Tales and Legends: I. The Witch Catillon - III. The Count Michael - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1Q4154TRQWkbNqT7vdGcOy",
+      "apple_music": "https://music.apple.com/us/album/tales-and-legends-i-the-witch-catillon-iii-the/1621082841?i=1621082846&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Bjølsen Ungdomskorps",
+      "result_piece": "Jungla, Poema ambientado en la Selva Africana",
+      "recording_title": "Jungla (Poem Set in the African Jungle, for Symphonic Band) - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7oJO6HXWOHMZmhkk4l2KA1",
+      "apple_music": "https://music.apple.com/us/album/jungla-poem-set-in-the-african-jungle-for-symphonic/1621082841?i=1621083215&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Drammen Konsertorkester",
+      "result_piece": "Awayday",
+      "recording_title": "Awayday - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5L7574bRchb1B6qiKPG5tL",
+      "apple_music": "https://music.apple.com/us/album/awayday-live/1621082841?i=1621083517&uo=4"
     },
     {
       "year": 2022,
@@ -108,99 +188,229 @@
       "band": "Drammen Konsertorkester",
       "result_piece": "Det gamle kvernhuset",
       "recording_title": "Det Gamle Kvernhuset, Op.204 (windband) - Live",
-      "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7iTXYdYxPN7EUn06rid2vj",
-      "apple_music": "https://music.apple.com/us/album/det-gamle-kvernhuset-op-204-windband-live/1621077640?i=1621079387&uo=4"
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6UNyQvY2DEjMs7TmQIq5Md",
+      "apple_music": "https://music.apple.com/us/album/det-gamle-kvernhuset-op-204-windband-live/1621082841?i=1621083523&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Drammen Konsertorkester",
+      "result_piece": "Nitro",
+      "recording_title": "Nitro - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/14xs9d7AerL9QDItqBcdLa",
+      "apple_music": "https://music.apple.com/us/album/nitro-live/1621082841?i=1621083527&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Gjøvik Bykorps",
+      "result_piece": "Elements of Nature",
+      "recording_title": "Elements of Nature - Suite - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3i9qtKJdewT6rAA4USYoR4",
+      "apple_music": "https://music.apple.com/us/album/elements-of-nature-suite-live/1621082841?i=1621083191&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Hov Musikkorps",
+      "result_piece": "Paris Sketches",
+      "recording_title": "Paris Sketches Homages for Wind Band: I. Saint Germain-des-Prés - II. Pigalle - III. Père Lachaise - IV. Les Halles - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3mYi1NH78DcDADRMqUnyaQ",
+      "apple_music": "https://music.apple.com/us/album/paris-sketches-homages-for-wind-band-i-saint-germain/1621082841?i=1621083769&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Hovin Musikkorps",
+      "result_piece": "Battle of Hearts",
+      "recording_title": "Battle of Hearts (Symphonic Poem) - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/65hOnjOtXk3xmDPaBR11sX",
+      "apple_music": "https://music.apple.com/us/album/battle-of-hearts-symphonic-poem-live/1621082841?i=1621083454&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Lungegaardens Musikkorps",
       "result_piece": "Between the Two Rivers",
-      "recording_title": "Between the Two Rivers (Variations on Ein Feste Burg) Concert Band (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/between-the-two-rivers-variations-on-ein-feste-burg/1621078172?i=1621079259&uo=4"
+      "recording_title": "Between the Two Rivers (Variations on Ein Feste Burg) Concert Band - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/33YmJ13kkqmwdimcvduPAs",
+      "apple_music": "https://music.apple.com/us/album/between-the-two-rivers-variations-on-ein-feste-burg/1621082841?i=1621084073&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Lørenskog Musikkorps",
+      "result_piece": "Les Trois Notes du Japon",
+      "recording_title": "Les trois notes du Japon: I. La danse des grues (Tancho cranes' mating dance) - II. La riviere enneigee (Snowy river) - III. Le fete du feu (Nebuta festival) - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/13q0KaKQkIKmD06Zc2plWl",
+      "apple_music": "https://music.apple.com/us/album/les-trois-notes-du-japon-i-la-danse-des-grues-tancho/1621082841?i=1621083199&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Sandvikens Ungdomskorps",
+      "result_piece": "Festiva Jubiloso",
+      "recording_title": "Festiva Jublioso - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7uCr3f0hvmyrSIjvXmziUW",
+      "apple_music": "https://music.apple.com/us/album/festiva-jublioso-live/1621082841?i=1621083532&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Sandvikens Ungdomskorps",
+      "result_piece": "Symphonic Songs for Band",
+      "recording_title": "Symphonic Songs for Band: I. Serenade - II. Spiritual - III. Celebration - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/62TdJVVv9klA1HpbPLb7Rr",
+      "apple_music": "https://music.apple.com/us/album/symphonic-songs-for-band-i-serenade-ii-spiritual-iii/1621082841?i=1621083541&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Greek Dances",
-      "recording_title": "Armenian Dances (Live)",
-      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+      "recording_title": "5 Greek Dances: I. Epirotikos 1 - II. Epirotikos 2 - III. Hostianos - IV. Kleftikos - V. Peloponnisiakos 1 - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tb4poVwNPWl9gtcBZ5NCP",
+      "apple_music": "https://music.apple.com/us/album/5-greek-dances-i-epirotikos-1-ii-epirotikos-2-iii-hostianos/1621082841?i=1621083756&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Strindheim Janitsjar",
+      "result_piece": "Fanfares and Fantasies",
+      "recording_title": "Fanfares and Fantasies - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2tBU8EsfQxP0sSGpwIEnVw",
+      "apple_music": "https://music.apple.com/us/album/fanfares-and-fantasies-live/1621082841?i=1621083209&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Strindheim Janitsjar",
+      "result_piece": "Symphonic Metamorphosis of themes by Carl Maria von Weber, 4. sats March",
+      "recording_title": "Symphonic Metamorphosis on Themes by Carl Maria von Weber (Concert Band): IV. March - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7p1SCfpjKfPPzAHlxXbLvd",
+      "apple_music": "https://music.apple.com/us/album/symphonic-metamorphosis-on-themes-by-carl-maria-von/1621082841?i=1621083204&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Sykkylven Janitsjarorkester",
+      "result_piece": "Angels in the Architecture",
+      "recording_title": "Angels in the Architecture - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1Yj4SsG4tAUtgoTs4ffbPA",
+      "apple_music": "https://music.apple.com/us/album/angels-in-the-architecture-live/1621082841?i=1621084079&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Tromsø Orkesterforenings Janitsjarkorps",
+      "result_piece": "Egmont",
+      "recording_title": "Egmont - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0SuA4UzFL48INIStJDTnRA",
+      "apple_music": "https://music.apple.com/us/album/egmont-live/1621082841?i=1621083761&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Tønsberg Janitsjarkorps",
+      "result_piece": "The Kings Go Forth",
+      "recording_title": "The Kings go Forth - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0GWP2PL7yK76fzwO08HsfR",
+      "apple_music": "https://music.apple.com/us/album/the-kings-go-forth-live/1621082841?i=1621083783&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "2. divisjon",
+      "band": "Vestre Aker Musikkorps",
+      "result_piece": "Dance Suite",
+      "recording_title": "Dance Suite: I. Moderato - II. Allegro molto - III. Allegro Vivace - IV. Molto tranquillo - V. Comodo - VI. Finale. Allegro - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7K9ptaD8tFnn5K6SMtauJB",
+      "apple_music": "https://music.apple.com/us/album/dance-suite-i-moderato-ii-allegro-molto-iii-allegro/1621082841?i=1621084082&uo=4"
     },
     {
       "year": 2022,
@@ -208,19 +418,19 @@
       "band": "Ådalsbruk Musikkforening",
       "result_piece": "Firefly",
       "recording_title": "FIREFLY for symphonic winds & percussion - Live",
-      "album": "Nm Janitsjar 2022 - 7. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1uxievZeGCaeyTUuM8irx7",
-      "apple_music": null
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/32W9XHoxc0zbEq7G6kHeVD",
+      "apple_music": "https://music.apple.com/us/album/firefly-for-symphonic-winds-percussion-live/1621082841?i=1621083434&uo=4"
     },
     {
       "year": 2022,
       "division": "2. divisjon",
       "band": "Ådalsbruk Musikkforening",
       "result_piece": "Terra Australis",
-      "recording_title": "Terra Mystica - Live",
-      "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4F2Nz1CrCjgrm6DjO69TW0",
-      "apple_music": null
+      "recording_title": "Terra Australis - Live",
+      "album": "Nm Janitsjar 2022 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1Vh2lt3Oakxq84fEYxrUV2",
+      "apple_music": "https://music.apple.com/us/album/terra-australis-live/1621082841?i=1621083444&uo=4"
     },
     {
       "year": 2022,
@@ -265,12 +475,32 @@
     {
       "year": 2022,
       "division": "3. divisjon",
+      "band": "Fet Janitsjar",
+      "result_piece": "Armenian Dances, Part 1",
+      "recording_title": "Armenian Dances Pt 1 - Live",
+      "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2vECIIDzXppJVzOosOEVr1",
+      "apple_music": "https://music.apple.com/us/album/armenian-dances-pt-1-live/1621077640?i=1621077805&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "3. divisjon",
       "band": "Fåberg Musikkforening",
       "result_piece": "Traveler",
       "recording_title": "Traveler - Live",
       "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/7jlKPkCGDtlQtC1SYlWX3E",
       "apple_music": "https://music.apple.com/us/album/traveler-live/1621077640?i=1621078516&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "3. divisjon",
+      "band": "Halsen Musikkforening",
+      "result_piece": "Aurora Borealis",
+      "recording_title": "Aurora Borealis - Live",
+      "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4qkVLPB3KDd7QwQHIXUmvp",
+      "apple_music": "https://music.apple.com/us/album/aurora-borealis-live/1621077640?i=1621077797&uo=4"
     },
     {
       "year": 2022,
@@ -291,6 +521,26 @@
       "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/3hbkixMSH7krRqxjEVmZR6",
       "apple_music": "https://music.apple.com/us/album/hymn-to-the-sun-with-the-beat-of-mother-earth-live/1621077640?i=1621078246&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "3. divisjon",
+      "band": "Musikklaget Brage",
+      "result_piece": "Ignition",
+      "recording_title": "Ignition - Live",
+      "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1Pfv2mYLE6vn7UXJ6KHfNf",
+      "apple_music": "https://music.apple.com/us/album/ignition-live/1621077640?i=1621077814&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "3. divisjon",
+      "band": "Musikklaget Ulf",
+      "result_piece": "Music for a Festival",
+      "recording_title": "Music for a Festival - Live",
+      "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3Gdu77TmT5ubCymxN9k76H",
+      "apple_music": "https://music.apple.com/us/album/music-for-a-festival-live/1621077640?i=1621079618&uo=4"
     },
     {
       "year": 2022,
@@ -395,6 +645,16 @@
     {
       "year": 2022,
       "division": "4. divisjon",
+      "band": "Byåsen Musikkorps",
+      "result_piece": "Music for a Festival",
+      "recording_title": "Music for a Festival - Live",
+      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3MGHWAtsbp6bJcTsTQ2lKA",
+      "apple_music": "https://music.apple.com/us/album/music-for-a-festival-live/1621078172?i=1621079274&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "4. divisjon",
       "band": "Eidsvoll Janitsjarkorps",
       "result_piece": "Tower of Babel",
       "recording_title": "The Tower of Babel - Live",
@@ -425,11 +685,21 @@
     {
       "year": 2022,
       "division": "4. divisjon",
+      "band": "Oppegård Janitsjar",
+      "result_piece": "Armenian Dances, Part 1",
+      "recording_title": "Armenian Dances - Live",
+      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4C6tfYqDpxAih8TXbuPNqo",
+      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1621078172?i=1621079609&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "4. divisjon",
       "band": "Oslo Postorkester",
       "result_piece": "Lincolnshire Posy, 2. sats",
-      "recording_title": "Lincolshire Posy: II. Horkstow Grange (Live)",
+      "recording_title": "Lincolshire Posy: II. Horkstow Grange - Live",
       "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/0KoWTMuRptwhMRdCmCgEAj",
       "apple_music": "https://music.apple.com/us/album/lincolshire-posy-ii-horkstow-grange-live/1621078172?i=1621079603&uo=4"
     },
     {
@@ -494,6 +764,16 @@
     },
     {
       "year": 2022,
+      "division": "4. divisjon",
+      "band": "Østre Gausdal Musikkforening",
+      "result_piece": "Armenian Dances, Part 1",
+      "recording_title": "Armenian Dances Pt 1 - Live",
+      "album": "Nm Janitsjar 2022 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/58FUDxTyInq4ABt00lahVc",
+      "apple_music": "https://music.apple.com/us/album/armenian-dances-pt-1-live/1621078172?i=1621079280&uo=4"
+    },
+    {
+      "year": 2022,
       "division": "5. divisjon",
       "band": "Alvdal-Tynset Janitsjarkorps",
       "result_piece": "Deliverance",
@@ -505,12 +785,42 @@
     {
       "year": 2022,
       "division": "5. divisjon",
+      "band": "Eina Musikkforening",
+      "result_piece": "Lake of the Moon",
+      "recording_title": "Lake of The Moon (Wind Band) - Live",
+      "album": "Nm Janitsjar 2022 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6E2GKc2WO4Z5hEfOrndDAd",
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-wind-band-live/1621078046?i=1621078407&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "5. divisjon",
+      "band": "Hamar Musikkorps",
+      "result_piece": "Hispanola",
+      "recording_title": "Hispaniola - Live",
+      "album": "Nm Janitsjar 2022 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5E6XF2cmxLDZmyJagXZs6v",
+      "apple_music": "https://music.apple.com/us/album/hispaniola-live/1621078046?i=1621078392&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "5. divisjon",
       "band": "Hønefoss Ungdomskorps",
       "result_piece": "A Little Stress Music",
       "recording_title": "A little stress music - Satire in four parts: I. Rush Hour - II. Promenade Waltz - III. Romance - IV. Monday Morning - Live",
       "album": "Nm Janitsjar 2022 - 5. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2bTMzz9QUklhPopbFDaSBe",
       "apple_music": "https://music.apple.com/us/album/a-little-stress-music-satire-in-four-parts-i-rush/1621078046?i=1621078406&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "5. divisjon",
+      "band": "Jernbanens Musikkorps Oslo",
+      "result_piece": "Bridges over the River Cam",
+      "recording_title": "Bridges Over the River Cam - Live",
+      "album": "Nm Janitsjar 2022 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5gW8mNVioDIkl3JFRNX7uI",
+      "apple_music": "https://music.apple.com/us/album/bridges-over-the-river-cam-live/1621078046?i=1621078639&uo=4"
     },
     {
       "year": 2022,
@@ -539,8 +849,18 @@
       "result_piece": "The Adventures of Baron Munchausen",
       "recording_title": "The Adventures of Baron Munchausen: Journey Through the Earth - Live",
       "album": "Nm Janitsjar 2022 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1qMJM4ZsU0IFxPagxKlQlT",
-      "apple_music": "https://music.apple.com/us/album/the-adventures-of-baron-munchausen-journey-through/1621078046?i=1621078399&uo=4"
+      "spotify": "https://open.spotify.com/track/7qFbPMsUY6NkSaI5PaqVen",
+      "apple_music": "https://music.apple.com/us/album/the-adventures-of-baron-munchausen-journey-through/1621078046?i=1621078629&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "5. divisjon",
+      "band": "Rælingen Musikklag",
+      "result_piece": "Music for a Festival",
+      "recording_title": "Music for a Festival - Live",
+      "album": "Nm Janitsjar 2022 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1a5zMjzOzi2DcBctjpPYX7",
+      "apple_music": "https://music.apple.com/us/album/music-for-a-festival-live/1621078046?i=1621078404&uo=4"
     },
     {
       "year": 2022,
@@ -567,9 +887,9 @@
       "division": "6. divisjon",
       "band": "Drøbak Musikkorps",
       "result_piece": "A Little Stress Music",
-      "recording_title": "A little stress music - Satire in four parts: I. Rush Hour - II. Promenade Waltz - III. Romance - IV. Monday Morning (Live)",
+      "recording_title": "A little stress music - Satire in four parts: I. Rush Hour - II. Promenade Waltz - III. Romance - IV. Monday Morning - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/3cCT3wszpFmWvIFbiWZAyn",
       "apple_music": "https://music.apple.com/us/album/a-little-stress-music-satire-in-four-parts-i-rush/1621077976?i=1621078812&uo=4"
     },
     {
@@ -577,9 +897,9 @@
       "division": "6. divisjon",
       "band": "Follebu og Vestre Gausdal Musikkforening",
       "result_piece": "Heaven's Light",
-      "recording_title": "Heaven's light (Live)",
+      "recording_title": "Heaven´s light - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/5ot6hVQ1LnnUJ1Hp1TzSHN",
       "apple_music": "https://music.apple.com/us/album/heavens-light-live/1621077976?i=1621078806&uo=4"
     },
     {
@@ -588,8 +908,8 @@
       "band": "Follebu og Vestre Gausdal Musikkforening",
       "result_piece": "Into the Joy of Spring",
       "recording_title": "Into the joy of spring: I. Winter's Fury - II. Spring's Awakening - III. Celebration Of Joy - Live",
-      "album": "Nm Janitsjar 2022 - 7. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/32N2mDkwReYUuLnI4eOPgL",
+      "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4ci5kT0QJpY1hNhZlPfWuh",
       "apple_music": "https://music.apple.com/us/album/into-the-joy-of-spring-i-winters-fury-ii/1621077976?i=1621078501&uo=4"
     },
     {
@@ -597,9 +917,9 @@
       "division": "6. divisjon",
       "band": "Hommelvik Musikkorps",
       "result_piece": "Eine Kleine Yiddishe Ragmusik",
-      "recording_title": "Eine Kleine Yiddische Ragmusik - Live",
-      "album": "Nm Janitsjar 2022 - 7. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7xcnkAwBBgwZZxfzKyCsR4",
+      "recording_title": "Eine Kleine Yiddishe Ragmusik - Live",
+      "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5UHHiUypaOcDyzQQWmHOFk",
       "apple_music": "https://music.apple.com/us/album/eine-kleine-yiddishe-ragmusik-live/1621077976?i=1621078192&uo=4"
     },
     {
@@ -607,9 +927,9 @@
       "division": "6. divisjon",
       "band": "Hommelvik Musikkorps",
       "result_piece": "Lord Tullamore",
-      "recording_title": "Lord Tullamore (Live)",
+      "recording_title": "Lord Tullamore - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4L48ftPz684CEjSIHLcTKm",
       "apple_music": "https://music.apple.com/us/album/lord-tullamore-live/1621077976?i=1621078205&uo=4"
     },
     {
@@ -617,9 +937,9 @@
       "division": "6. divisjon",
       "band": "Jevnaker Ungdomskorps",
       "result_piece": "Diogenes",
-      "recording_title": "Diogenes (Live)",
+      "recording_title": "Diogenes - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/0hK7fUwlAxwRbGnMFJVHdu",
       "apple_music": "https://music.apple.com/us/album/diogenes-live/1621077976?i=1621078485&uo=4"
     },
     {
@@ -627,9 +947,9 @@
       "division": "6. divisjon",
       "band": "Klæbu Musikkorps",
       "result_piece": "Puszta (Four Gypsi Dances)",
-      "recording_title": "Puszta (Live)",
+      "recording_title": "Puszta - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/5EYgP9usqAkjH11oAapakR",
       "apple_music": "https://music.apple.com/us/album/puszta-live/1621077976?i=1621077983&uo=4"
     },
     {
@@ -638,8 +958,8 @@
       "band": "Lørenskog Blåseensemble",
       "result_piece": "Banja Luka",
       "recording_title": "Banja Luka - Live",
-      "album": "Nm Janitsjar 2022 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/47WsrzsUIjyiqGc0MEPKT5",
+      "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1rwORJSNax4dSLaQeJSx2M",
       "apple_music": "https://music.apple.com/us/album/banja-luka-live/1621077976?i=1621077987&uo=4"
     },
     {
@@ -647,9 +967,9 @@
       "division": "6. divisjon",
       "band": "Moss og omegn Janitsjar",
       "result_piece": "Breaking Point",
-      "recording_title": "Breaking Point (Live)",
+      "recording_title": "Breaking Point - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/1sr58TUZX0OQgLQHCaCP2W",
       "apple_music": "https://music.apple.com/us/album/breaking-point-live/1621077976?i=1621078190&uo=4"
     },
     {
@@ -657,9 +977,9 @@
       "division": "6. divisjon",
       "band": "Moss og omegn Janitsjar",
       "result_piece": "Mercury March",
-      "recording_title": "Mercury (Live)",
+      "recording_title": "Mercury - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/42aakeOwlqU1zRIMoqe58r",
       "apple_music": "https://music.apple.com/us/album/mercury-live/1621077976?i=1621078187&uo=4"
     },
     {
@@ -667,9 +987,9 @@
       "division": "6. divisjon",
       "band": "Namsos Musikkorps",
       "result_piece": "Hispanola",
-      "recording_title": "Hispaniola (Live)",
-      "album": "Nm Janitsjar 2022 - 5. divisjon (Live)",
-      "spotify": null,
+      "recording_title": "Hispaniola (Concert Band) - Live",
+      "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/674oOjCSIWBulJfhYQUyT5",
       "apple_music": "https://music.apple.com/us/album/hispaniola-live/1621078046?i=1621078392&uo=4"
     },
     {
@@ -677,9 +997,9 @@
       "division": "6. divisjon",
       "band": "Skatval Hornmusikklag",
       "result_piece": "Pilatus: Mountain of Dragons",
-      "recording_title": "Pilatus: Mountain of Dragons (Live)",
+      "recording_title": "Pilatus: Mountain of Dragons - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4A4Q9YAF3HRR20XlcDUfa9",
       "apple_music": "https://music.apple.com/us/album/pilatus-mountain-of-dragons-live/1621077976?i=1621078490&uo=4"
     },
     {
@@ -687,9 +1007,9 @@
       "division": "6. divisjon",
       "band": "Strinda Ungdomskorps",
       "result_piece": "Skamslått",
-      "recording_title": "Skamslått (Live)",
+      "recording_title": "Skamslått - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/14FXTfqrrQxs8XR3vX6kGc",
       "apple_music": "https://music.apple.com/us/album/skamsl%C3%A5tt-live/1621077976?i=1621078183&uo=4"
     },
     {
@@ -697,9 +1017,9 @@
       "division": "6. divisjon",
       "band": "Strinda Ungdomskorps",
       "result_piece": "Tognum Power",
-      "recording_title": "Tognum Power (Live)",
+      "recording_title": "Tognum Power - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/7B9S0VjD74MzfXaECIA4MG",
       "apple_music": "https://music.apple.com/us/album/tognum-power-live/1621077976?i=1621078185&uo=4"
     },
     {
@@ -707,9 +1027,9 @@
       "division": "6. divisjon",
       "band": "Vålerenga Janitsjarkorps",
       "result_piece": "Utopia",
-      "recording_title": "Utopia (Live)",
+      "recording_title": "Utopia - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/23DOiW5Djz9mKuDD5HSzaM",
       "apple_music": "https://music.apple.com/us/album/utopia-live/1621077976?i=1621078807&uo=4"
     },
     {
@@ -717,9 +1037,9 @@
       "division": "6. divisjon",
       "band": "Åndalsnes Musikkforening",
       "result_piece": "Time for Celebration",
-      "recording_title": "Time for Celebration (Live)",
+      "recording_title": "Time for Celebration - Live",
       "album": "Nm Janitsjar 2022 - 6. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/0guzTGjSufLdt08uMlFt98",
       "apple_music": "https://music.apple.com/us/album/time-for-celebration-live/1621077976?i=1621078496&uo=4"
     },
     {
@@ -880,6 +1200,26 @@
       "recording_title": "69 marching bars of leftovers from an old century - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/6ceylNdfTlv8ooE18fFh6f",
+      "apple_music": "https://music.apple.com/us/album/69-marching-bars-of-leftovers-from-an-old-century-live/1621715628?i=1621715637&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "Goldberg 2012",
+      "recording_title": "Goldberg 2012 - Live",
+      "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/10qvtEtTev4rVUVxJhn8Cu",
+      "apple_music": "https://music.apple.com/us/album/goldberg-2012-live/1621715628?i=1621715645&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "King Mangoberry, 1. og 3. sats",
+      "recording_title": "Goldberg 2012 - Live",
+      "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/10qvtEtTev4rVUVxJhn8Cu",
       "apple_music": null
     },
     {
@@ -890,7 +1230,7 @@
       "recording_title": "Sinfonia di Soffiatori nr 3 - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/6PP5397kSeWQjlCjcAAr2c",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/sinfonia-di-soffiatori-nr-3-live/1621715628?i=1621716049&uo=4"
     },
     {
       "year": 2022,
@@ -900,7 +1240,7 @@
       "recording_title": "Equus - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/0CKorKD0PwO9OG2PhkNAHf",
-      "apple_music": "https://music.apple.com/us/album/equus-concert-band-live/1621096649?i=1621097440&uo=4"
+      "apple_music": "https://music.apple.com/us/album/equus-live/1621715628?i=1621716046&uo=4"
     },
     {
       "year": 2022,
@@ -910,7 +1250,7 @@
       "recording_title": "Instant Music - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/4EA6PQviVmmq5vzAeQ9EGr",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/instant-music-live/1621715628?i=1621716044&uo=4"
     },
     {
       "year": 2022,
@@ -920,7 +1260,27 @@
       "recording_title": "Extreme make-over: Metamorphoses on a Theme - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/0bZyWFWbF0BphFInwdzG7U",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/extreme-make-over-metamorphoses-on-a-theme-live/1621715628?i=1621716244&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "Elite",
+      "band": "Mo Hornmusikk",
+      "result_piece": "Symphony no. 6, A Cotswold Symphony",
+      "recording_title": "A Cotswold Symphony, op. 109b - Live",
+      "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3uTDn0WeyyfumFU36CbMxm",
+      "apple_music": "https://music.apple.com/us/album/a-cotswold-symphony-op-109b-live/1621715628?i=1621716429&uo=4"
+    },
+    {
+      "year": 2022,
+      "division": "Elite",
+      "band": "Musikkforeningen Nidarholm",
+      "result_piece": "Danse Satanique",
+      "recording_title": "Danse Satanique - Live",
+      "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2QK8yu2GQMTJU0Sel1mNOP",
+      "apple_music": "https://music.apple.com/us/album/danse-satanique-live/1621715628?i=1621716226&uo=4"
     },
     {
       "year": 2022,
@@ -930,7 +1290,7 @@
       "recording_title": "Mountain Song and Arias - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/1DZK70ocrXP6sKNr4DMHuY",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/mountain-song-and-arias-live/1621715628?i=1621716060&uo=4"
     },
     {
       "year": 2022,
@@ -940,7 +1300,7 @@
       "recording_title": "Symfony no.3: Variations on the Porazzi Theme of Wagner - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/3Z66UgtlvidzU4vSDc59zD",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/symfony-no-3-variations-on-the-porazzi-theme-of-wagner-live/1621715628?i=1621716229&uo=4"
     },
     {
       "year": 2022,
@@ -950,7 +1310,7 @@
       "recording_title": "Macbeth - Music to Act 1 of Shakespeares play - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/1KEq8w928bFRosn2UzDFjD",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/macbeth-music-to-act-1-of-shakespeares-play-live/1621715628?i=1621716441&uo=4"
     },
     {
       "year": 2022,
@@ -960,7 +1320,7 @@
       "recording_title": "Organ Sonata No.4, BWV 528, II: Andante [Adagio] - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/2W3zm3Zk8mxtDDUayCkr9o",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/organ-sonata-no-4-bwv-528-ii-andante-adagio-live/1621715628?i=1621716438&uo=4"
     },
     {
       "year": 2022,
@@ -970,7 +1330,7 @@
       "recording_title": "Aulos symphony - Live",
       "album": "Nm Janitsjar 2022 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/1VarjdRGgr4DmGNM0PfqnI",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/aulos-symphony-live/1621715628?i=1621715631&uo=4"
     }
   ]
 }

--- a/apps/band-positions/public/data/streaming/wind/2023.json
+++ b/apps/band-positions/public/data/streaming/wind/2023.json
@@ -980,7 +980,7 @@
       "recording_title": "Eldorado - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5U6YW7F7qhaPrAhLReBNrX",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/eldorado-live/1681182666?i=1681183341&uo=4"
     },
     {
       "year": 2023,
@@ -990,7 +990,7 @@
       "recording_title": "The Adventures of Baron Munchausen - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1trqi4dV0CoQV2lD2KXNdL",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/the-adventures-of-baron-munchausen-live/1681182666?i=1681183083&uo=4"
     },
     {
       "year": 2023,
@@ -1000,7 +1000,7 @@
       "recording_title": "Ross Roy - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/73oWqEFJJCivVgIziQmF93",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/ross-roy-live/1681182666?i=1681184275&uo=4"
     },
     {
       "year": 2023,
@@ -1010,7 +1010,7 @@
       "recording_title": "Where Eagles Soar - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/16F3ZY4nKu6VjRjKUVBSCb",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/where-eagles-soar-live/1681182666?i=1681184281&uo=4"
     },
     {
       "year": 2023,
@@ -1020,7 +1020,7 @@
       "recording_title": "First Suite for Military Band, No. 1: Chaconne - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6xasp3p4B7RAOU8sCytGor",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/first-suite-for-military-band-no-1-chaconne-live/1681182666?i=1681182675&uo=4"
     },
     {
       "year": 2023,
@@ -1030,7 +1030,7 @@
       "recording_title": "Les Parapluies de Cherboourg - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/3BjsUrG2yLUJFloDqzo9hv",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/les-parapluies-de-cherboourg-live/1681182666?i=1681183079&uo=4"
     },
     {
       "year": 2023,
@@ -1040,7 +1040,7 @@
       "recording_title": "Samtidig, ein annan stad enn no - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/4jMcDsmMv6UbsBWZ8m6Sbr",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/samtidig-ein-annan-stad-enn-no-live/1681182666?i=1681184043&uo=4"
     },
     {
       "year": 2023,
@@ -1050,7 +1050,7 @@
       "recording_title": "Edenstrand - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1G6UgyIu0JYbLTcmXXMRud",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/edenstrand-live/1681182666?i=1681184032&uo=4"
     },
     {
       "year": 2023,
@@ -1060,7 +1060,7 @@
       "recording_title": "Victory: Samtidig, ein annan stad enn no - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6HnDPIg0I7EPzNOKqP6GcR",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/victory-samtidig-ein-annan-stad-enn-no-live/1681182666?i=1681184034&uo=4"
     },
     {
       "year": 2023,
@@ -1070,7 +1070,7 @@
       "recording_title": "Music for a Solemnity - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1p4psz5bB4voVUUTESFjNt",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/music-for-a-solemnity-live/1681182666?i=1681183789&uo=4"
     },
     {
       "year": 2023,
@@ -1080,7 +1080,7 @@
       "recording_title": "A Malvern Suite - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5VNh1uQps8zh1GK6rSIb2e",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/a-malvern-suite-live/1681182666?i=1681183796&uo=4"
     },
     {
       "year": 2023,
@@ -1090,7 +1090,7 @@
       "recording_title": "Armenian Dances - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0CGoCMusnQtO7wutKcrqVv",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1681182666?i=1681183631&uo=4"
     },
     {
       "year": 2023,
@@ -1100,7 +1100,7 @@
       "recording_title": "Dawn of a New Day - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/7h0n8AiiEuvu7vAnimK4K0",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/dawn-of-a-new-day-live/1681182666?i=1681183793&uo=4"
     },
     {
       "year": 2023,
@@ -1110,7 +1110,7 @@
       "recording_title": "Persis - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6b9uw3Ihnu4oCcE0ymku4p",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/persis-live/1681182666?i=1681183794&uo=4"
     },
     {
       "year": 2023,
@@ -1120,7 +1120,7 @@
       "recording_title": "Prelude, Siciliano and Rondo - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2qe6oZ9txFtcCvhhs5ptlq",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/prelude-siciliano-and-rondo-live/1681182666?i=1681183338&uo=4"
     },
     {
       "year": 2023,
@@ -1130,7 +1130,7 @@
       "recording_title": "Street Tango - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/4u5aWaD4uskfwRufAntttX",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/street-tango-live/1681182666?i=1681183090&uo=4"
     },
     {
       "year": 2023,
@@ -1140,7 +1140,7 @@
       "recording_title": "D-day - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5sEJceG9bpjewVr6mMAdQY",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/d-day-live/1681182666?i=1681183087&uo=4"
     },
     {
       "year": 2023,
@@ -1150,7 +1150,7 @@
       "recording_title": "Eine Kleine Yiddishe Ragmusik - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0PxAJ3IPmpc2CaNRuIo9Oo",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/eine-kleine-yiddishe-ragmusik-live/1681182666?i=1681184269&uo=4"
     },
     {
       "year": 2023,
@@ -1160,7 +1160,7 @@
       "recording_title": "Tales and Myths of Gothia - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2xUA2neXltPO9gpaP9of58",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/tales-and-myths-of-gothia-live/1681182666?i=1681184271&uo=4"
     },
     {
       "year": 2023,
@@ -1170,7 +1170,7 @@
       "recording_title": "Street Tango - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2jcFxGDnGD1vir8uA6vWhF",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/street-tango-live/1681182666?i=1681183607&uo=4"
     },
     {
       "year": 2023,
@@ -1180,7 +1180,7 @@
       "recording_title": "Tales and Myths of Gothia - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/63i0Bn9xdEgS4F7h5fcmBQ",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/tales-and-myths-of-gothia-live/1681182666?i=1681183362&uo=4"
     },
     {
       "year": 2023,
@@ -1190,7 +1190,7 @@
       "recording_title": "Pilatus: Mountain of Dragons - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6TiDAJWvAeGB4qWeMVdKCD",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/pilatus-mountain-of-dragons-live/1681182666?i=1681184267&uo=4"
     },
     {
       "year": 2023,

--- a/apps/band-positions/public/data/streaming/wind/2023.json
+++ b/apps/band-positions/public/data/streaming/wind/2023.json
@@ -17,10 +17,10 @@
       "division": "1. divisjon",
       "band": "Asker Musikkorps",
       "result_piece": "Tales and Legends, 1. og 2. sats",
-      "recording_title": "Tales and Legends - Live",
+      "recording_title": "Tales & Legends: I. - II. - Live",
       "album": "NM Janitsjar 2023 - 1. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2uQgdFMHZiv4Nk2Z2d6TNm",
-      "apple_music": "https://music.apple.com/us/album/tales-and-legends-live/1681187798?i=1681188408&uo=4"
+      "spotify": "https://open.spotify.com/track/0kOpIjVtFQwoIE6HA9hWWC",
+      "apple_music": "https://music.apple.com/us/album/tales-legends-i-ii-live/1681187798?i=1681188183&uo=4"
     },
     {
       "year": 2023,
@@ -90,7 +90,7 @@
       "recording_title": "Asgard Symphony no. 1 - Live",
       "album": "NM Janitsjar 2023 - 1. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/4HbB09NZdp8naP7eMXPbQu",
-      "apple_music": "https://music.apple.com/us/album/symphony-no-4-live/1680515141?i=1680515326&uo=4"
+      "apple_music": "https://music.apple.com/us/album/asgard-symphony-no-1-live/1681187798?i=1681188315&uo=4"
     },
     {
       "year": 2023,
@@ -167,10 +167,10 @@
       "division": "1. divisjon",
       "band": "Sande Musikkorps",
       "result_piece": "Norsk Rapsodi nr. 1",
-      "recording_title": "Norsk Rapsodi Nr. 1 - Live",
-      "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4vml3HvFIVRGaJ9jnXznSZ",
-      "apple_music": "https://music.apple.com/us/album/norsk-rapsodi-nr-1-live/1680515141?i=1680515799&uo=4"
+      "recording_title": "Rhapsodie Norvegienne Nr. 1 - Live",
+      "album": "NM Janitsjar 2023 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6L41L1Y1tHNLj8v0JF6LqR",
+      "apple_music": "https://music.apple.com/us/album/rhapsodie-norvegienne-nr-1-live/1681187798?i=1681188297&uo=4"
     },
     {
       "year": 2023,
@@ -186,11 +186,21 @@
       "year": 2023,
       "division": "1. divisjon",
       "band": "Skjold Nesttun Janitsjar",
+      "result_piece": "An Gé Fhián",
+      "recording_title": "The Wild Goose - Live",
+      "album": "NM Janitsjar 2023 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3TFKu5SAVFujNmrK7Ub4ev",
+      "apple_music": null
+    },
+    {
+      "year": 2023,
+      "division": "1. divisjon",
+      "band": "Skjold Nesttun Janitsjar",
       "result_piece": "Fanfare and Choral",
       "recording_title": "Fanfare og Koral - Live",
       "album": "NM Janitsjar 2023 - 1. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0vYaZRLCXj2GOMs5QuKdnO",
-      "apple_music": "https://music.apple.com/us/album/fanfare-and-choral-live/1680806260?i=1680806967&uo=4"
+      "apple_music": "https://music.apple.com/us/album/fanfare-og-koral-live/1681187798?i=1681188026&uo=4"
     },
     {
       "year": 2023,
@@ -215,32 +225,242 @@
     {
       "year": 2023,
       "division": "2. divisjon",
+      "band": "Bispehaugen Ungdomskorps",
+      "result_piece": "Saga Candida",
+      "recording_title": "Saga Candida - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2AoiP2XKRdL3UL3PvkOzVq",
+      "apple_music": "https://music.apple.com/us/album/saga-candida-live/1681188276?i=1681189820&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Bjølsen Ungdomskorps",
+      "result_piece": "Ride",
+      "recording_title": "Ride - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3iGoWgZsMx0VroN6igjqBk",
+      "apple_music": "https://music.apple.com/us/album/ride-live/1681188276?i=1681188701&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
       "band": "Bjølsen Ungdomskorps",
       "result_piece": "Spiritual Planet",
-      "recording_title": "Scintallant (Live)",
-      "album": "NM Janitsjar 2023 - 1. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/scintallant-live/1681187798?i=1681188018&uo=4"
+      "recording_title": "Spiritual Planet - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1BbwT6NAmulL2waL3qyVsP",
+      "apple_music": "https://music.apple.com/us/album/spiritual-planet-live/1681188276?i=1681188957&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Drammen Konsertorkester",
+      "result_piece": "High Wire",
+      "recording_title": "High Wire - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7BO5NCtTnxuf79s74CD2rb",
+      "apple_music": "https://music.apple.com/us/album/high-wire-live/1681188276?i=1681188974&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Drammen Konsertorkester",
+      "result_piece": "Poéme du Feu",
+      "recording_title": "Poeme du Feu - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7zpfyGoMELALM12vqLVTSj",
+      "apple_music": "https://music.apple.com/us/album/poeme-du-feu-live/1681188276?i=1681188964&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Gjøvik Bykorps",
+      "result_piece": "La Procession du Roico",
+      "recording_title": "La Procession du Roico - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4nkdXid3u2KkKU4Q2ypgHI",
+      "apple_music": "https://music.apple.com/us/album/la-procession-du-roico-live/1681188276?i=1681189593&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Gjøvik Bykorps",
+      "result_piece": "Wer ist Elise",
+      "recording_title": "Wer ist Elise - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4NYtJ9Ea8MaUQrJs4Utihu",
+      "apple_music": "https://music.apple.com/us/album/wer-ist-elise-live/1681188276?i=1681189597&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Hov Musikkorps",
+      "result_piece": "Danzón no. 2",
+      "recording_title": "Danzón Nr. 2 - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0uDqKiea524jeLN7Ik1wwk",
+      "apple_music": "https://music.apple.com/us/album/danz%C3%B3n-nr-2-live/1681188276?i=1681188450&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Hov Musikkorps",
+      "result_piece": "Hjalar-Ljod",
+      "recording_title": "Hjalar-Ljord - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3v46TnyIIlko1NdXxGoMin",
+      "apple_music": "https://music.apple.com/us/album/hjalar-ljord-live/1681188276?i=1681188445&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Hovin Musikkorps",
+      "result_piece": "Armenian Dances, Part 1",
+      "recording_title": "Armenian Dances: Part 1 - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7BxRk4p7DlN52Bj1Gp3FnG",
+      "apple_music": "https://music.apple.com/us/album/armenian-dances-part-1-live/1681188276?i=1681188681&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Hovin Musikkorps",
+      "result_piece": "Perseus",
+      "recording_title": "Perseus - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2VJKjGNwxPEnuYtv9HpAW3",
+      "apple_music": "https://music.apple.com/us/album/perseus-live/1681188276?i=1681188690&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Lungegaardens Musikkorps",
+      "result_piece": "Villfar",
+      "recording_title": "Villfar - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1ff2L7AkWtU7ViY3t4I4Iz",
+      "apple_music": "https://music.apple.com/us/album/villfar-live/1681188276?i=1681189131&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Musikklaget Brage",
+      "result_piece": "Fragile Oasis",
+      "recording_title": "Fragile Oasis - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1CW6ESDt3o3k6rGrj4Rnm5",
+      "apple_music": "https://music.apple.com/us/album/fragile-oasis-live/1681188276?i=1681188458&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Musikklaget Brage",
+      "result_piece": "Start-Up",
+      "recording_title": "Start-Up - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7uQXs1usJhacWVFZCbAMkj",
+      "apple_music": "https://music.apple.com/us/album/start-up-live/1681188276?i=1681188454&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Sandvikens Ungdomskorps",
+      "result_piece": "Carnival",
+      "recording_title": "Carnival - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2BBSUh0G8HpYW5IanzcOfs",
+      "apple_music": "https://music.apple.com/us/album/carnival-live/1681188276?i=1681189401&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Sandvikens Ungdomskorps",
+      "result_piece": "Ride",
+      "recording_title": "Ride - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6mxHW3x2qsNT83S3lNSJso",
+      "apple_music": "https://music.apple.com/us/album/ride-live/1681188276?i=1681189416&uo=4"
     },
     {
       "year": 2023,
       "division": "2. divisjon",
       "band": "Sinsen Konsertorkester",
       "result_piece": "Symphony no. 3 “Slavyanskaya”",
-      "recording_title": "Symphony No. 4 - Live",
-      "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3gMUdgZ3U7gsghdsYkL05f",
-      "apple_music": null
+      "recording_title": "Symphony No. 3 \"Slavyanskaya\" - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2ckXiXLmSBLbMQ6h6z8uke",
+      "apple_music": "https://music.apple.com/us/album/symphony-no-3-slavyanskaya-live/1681188276?i=1681189153&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Strindheim Janitsjar",
+      "result_piece": "Jungla, Poema ambientado en la Selva Africana",
+      "recording_title": "Jungla, Poema ambientado en la Selva Africana - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/033r0JxAQctQN8Rm9bos7D",
+      "apple_music": "https://music.apple.com/us/album/jungla-poema-ambientado-en-la-selva-africana-live/1681188276?i=1681189588&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Sykkylven Janitsjarorkester",
+      "result_piece": "Sidus",
+      "recording_title": "Sidus - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4T8PpLy2aDaXuiPAc7VMfv",
+      "apple_music": "https://music.apple.com/us/album/sidus-live/1681188276?i=1681189150&uo=4"
     },
     {
       "year": 2023,
       "division": "2. divisjon",
       "band": "Tromsø Orkesterforenings Janitsjarkorps",
       "result_piece": "Fleodrodum",
-      "recording_title": "Fleodrodum (Live)",
-      "album": "Nm Janitsjar 2023 - 4. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/fleodrodum-live/1680508500?i=1680509351&uo=4"
+      "recording_title": "Fleododrum - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0l5qEzGuWnxIjTJD74JdOi",
+      "apple_music": "https://music.apple.com/us/album/fleododrum-live/1681188276?i=1681189919&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Tønsberg Janitsjarkorps",
+      "result_piece": "Audivi Media Nocte",
+      "recording_title": "Audivi Media Nocte - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2NoO3EpASV3CM3dK1sEEKM",
+      "apple_music": "https://music.apple.com/us/album/audivi-media-nocte-live/1681188276?i=1681188464&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Vestre Aker Musikkorps",
+      "result_piece": "Stabsarabesk",
+      "recording_title": "Stabsarabesk - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1xQJLGS6YuHQqwapIoXgzw",
+      "apple_music": "https://music.apple.com/us/album/stabsarabesk-live/1681188276?i=1681189143&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Vestre Aker Musikkorps",
+      "result_piece": "Sørgemarsj til minne om Richard Nordraak, Op. 117",
+      "recording_title": "Sørgemarsj (til minne om Rikard Nordraak) - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0ubIbae6of49LqWzHBLU4r",
+      "apple_music": "https://music.apple.com/us/album/s%C3%B8rgemarsj-til-minne-om-rikard-nordraak-live/1681188276?i=1681189137&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "2. divisjon",
+      "band": "Ådalsbruk Musikkforening",
+      "result_piece": "Divertimento",
+      "recording_title": "Divertimento - Live",
+      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2h3CkzGJhHpw9QbkgtfrwB",
+      "apple_music": "https://music.apple.com/us/album/divertimento-live/1681188276?i=1681189581&uo=4"
     },
     {
       "year": 2023,
@@ -269,8 +489,8 @@
       "result_piece": "Machu Picchu - City in the sky - the mystery of the hidden sun Temple",
       "recording_title": "Machu Picchu - City in the Sky The Mystery of the Hidden Sun Temple - Live",
       "album": "Nm Janitsjar 2023 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7FXBbPXsO0QOInWk5MBWUw",
-      "apple_music": "https://music.apple.com/us/album/machu-picchu-city-in-the-sky-the-mystery-of/1680806260?i=1680806453&uo=4"
+      "spotify": "https://open.spotify.com/track/4RgP8rqrNtchFmz5XteQ35",
+      "apple_music": "https://music.apple.com/us/album/machu-picchu-city-in-the-sky-the-mystery-of/1680806260?i=1680806782&uo=4"
     },
     {
       "year": 2023,
@@ -299,17 +519,17 @@
       "result_piece": "Machu Picchu - City in the sky - the mystery of the hidden sun Temple",
       "recording_title": "Machu Picchu - City in the Sky The Mystery of the Hidden Sun Temple - Live",
       "album": "Nm Janitsjar 2023 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7FXBbPXsO0QOInWk5MBWUw",
-      "apple_music": "https://music.apple.com/us/album/machu-picchu-city-in-the-sky-the-mystery-of/1680806260?i=1680806453&uo=4"
+      "spotify": "https://open.spotify.com/track/6TKgUAtg6APqMOIbKJ4qNO",
+      "apple_music": "https://music.apple.com/us/album/machu-picchu-city-in-the-sky-the-mystery-of/1680806260?i=1680807212&uo=4"
     },
     {
       "year": 2023,
       "division": "3. divisjon",
       "band": "Halsen Musikkforening",
       "result_piece": "Armenian Dances, Part 1",
-      "recording_title": "Armenian Dances: Part 1 - Live",
-      "album": "Nm Janitsjar 2023 - 2. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7BxRk4p7DlN52Bj1Gp3FnG",
+      "recording_title": "Armenian Dances: I. Part 1 - Live",
+      "album": "Nm Janitsjar 2023 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1LcF4lgPX9tOopJovxSaCu",
       "apple_music": "https://music.apple.com/us/album/armenian-dances-i-part-1-live/1680806260?i=1680807221&uo=4"
     },
     {
@@ -381,6 +601,16 @@
       "album": "Nm Janitsjar 2023 - 3. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/3VRZt3xJAUO7rz6nLmkpwI",
       "apple_music": "https://music.apple.com/us/album/made-in-bergen-live/1680806260?i=1680806471&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "3. divisjon",
+      "band": "Sagene Janitsjarkorps",
+      "result_piece": "Childrens March",
+      "recording_title": "Children´s March: \"over the hill and far away\" - Live",
+      "album": "Nm Janitsjar 2023 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4d3VCtIMgrNVG441Hvwx6K",
+      "apple_music": "https://music.apple.com/us/album/childrens-march-over-the-hill-and-far-away-live/1680806260?i=1680806776&uo=4"
     },
     {
       "year": 2023,
@@ -466,6 +696,16 @@
       "year": 2023,
       "division": "4. divisjon",
       "band": "Eidsvoll Janitsjarkorps",
+      "result_piece": "Cavetowns \"Cappadocia\"",
+      "recording_title": "Cavetaowns \"Cappadocia\" - Live",
+      "album": "Nm Janitsjar 2023 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2DOrAIOprA591J4urolx71",
+      "apple_music": "https://music.apple.com/us/album/cavetaowns-cappadocia-live/1680508500?i=1680509906&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "4. divisjon",
+      "band": "Eidsvoll Janitsjarkorps",
       "result_piece": "Fanfare",
       "recording_title": "Fanfare - The Benefication from Sky and Mother Earth - Live",
       "album": "Nm Janitsjar 2023 - 4. divisjon (Live)",
@@ -478,8 +718,8 @@
       "band": "Fana Musikklag",
       "result_piece": "Hispanola",
       "recording_title": "Hispaniola (Concert Band) - Live",
-      "album": "Nm Janitsjar 2023 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/5rMGwvOSSMrgYvVAAeqy2X",
+      "album": "Nm Janitsjar 2023 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3AYEnTw1TlOoS1jndPhOka",
       "apple_music": "https://music.apple.com/us/album/hispaniola-concert-band-live/1680508500?i=1680509818&uo=4"
     },
     {
@@ -488,8 +728,8 @@
       "band": "Hamar Musikkorps",
       "result_piece": "The Story of Anne Frank",
       "recording_title": "The Story of Anne Frank - Live",
-      "album": "Nm Janitsjar 2023 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2wDsJSFsgxKaCHlPdiopqL",
+      "album": "Nm Janitsjar 2023 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2GB5sdOELxeKTidV1d4iBo",
       "apple_music": "https://music.apple.com/us/album/the-story-of-anne-frank-live/1680508500?i=1680509332&uo=4"
     },
     {
@@ -528,9 +768,9 @@
       "band": "Oppegård Janitsjar",
       "result_piece": "Lake of the Moon",
       "recording_title": "Lake of The Moon (Wind Band) - Live",
-      "album": "Nm Janitsjar 2023 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7LfVzXuuciaOZwPs08Pl3S",
-      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-wind-band-live/1680508500?i=1680509827&uo=4"
+      "album": "Nm Janitsjar 2023 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/46lxeIEGy6IW7ak3vzhaXv",
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-wind-band-live/1680508500?i=1680509924&uo=4"
     },
     {
       "year": 2023,
@@ -548,8 +788,8 @@
       "band": "Skedsmo Janitsjarorkester",
       "result_piece": "Lake of the Moon",
       "recording_title": "Lake of The Moon (Wind Band) - Live",
-      "album": "Nm Janitsjar 2023 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7LfVzXuuciaOZwPs08Pl3S",
+      "album": "Nm Janitsjar 2023 - 4. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4vLZLIg3xMnWmwmv0NG4gP",
       "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-wind-band-live/1680508500?i=1680509827&uo=4"
     },
     {
@@ -740,7 +980,7 @@
       "recording_title": "Eldorado - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5U6YW7F7qhaPrAhLReBNrX",
-      "apple_music": "https://music.apple.com/us/album/eldorado-live/1681182666?i=1681183341&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -750,17 +990,17 @@
       "recording_title": "The Adventures of Baron Munchausen - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1trqi4dV0CoQV2lD2KXNdL",
-      "apple_music": "https://music.apple.com/us/album/the-adventures-of-baron-munchausen-live/1681182666?i=1681183083&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
       "division": "6. divisjon",
       "band": "Follebu og Vestre Gausdal Musikkforening",
       "result_piece": "Ross Roy, Overture for Band",
-      "recording_title": "Ross Roy (Live)",
+      "recording_title": "Ross Roy - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/ross-roy-live/1681182666?i=1681184275&uo=4"
+      "spotify": "https://open.spotify.com/track/73oWqEFJJCivVgIziQmF93",
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -770,7 +1010,7 @@
       "recording_title": "Where Eagles Soar - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/16F3ZY4nKu6VjRjKUVBSCb",
-      "apple_music": "https://music.apple.com/us/album/where-eagles-soar-live/1681182666?i=1681184281&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -780,7 +1020,7 @@
       "recording_title": "First Suite for Military Band, No. 1: Chaconne - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6xasp3p4B7RAOU8sCytGor",
-      "apple_music": "https://music.apple.com/us/album/first-suite-for-military-band-no-1-chaconne-live/1681182666?i=1681182675&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -790,7 +1030,7 @@
       "recording_title": "Les Parapluies de Cherboourg - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/3BjsUrG2yLUJFloDqzo9hv",
-      "apple_music": "https://music.apple.com/us/album/les-parapluies-de-cherboourg-live/1681182666?i=1681183079&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -800,7 +1040,7 @@
       "recording_title": "Samtidig, ein annan stad enn no - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/4jMcDsmMv6UbsBWZ8m6Sbr",
-      "apple_music": "https://music.apple.com/us/album/samtidig-ein-annan-stad-enn-no-live/1681182666?i=1681184043&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -810,7 +1050,7 @@
       "recording_title": "Edenstrand - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1G6UgyIu0JYbLTcmXXMRud",
-      "apple_music": "https://music.apple.com/us/album/edenstrand-live/1681182666?i=1681184032&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -820,7 +1060,7 @@
       "recording_title": "Victory: Samtidig, ein annan stad enn no - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6HnDPIg0I7EPzNOKqP6GcR",
-      "apple_music": "https://music.apple.com/us/album/victory-samtidig-ein-annan-stad-enn-no-live/1681182666?i=1681184034&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -830,7 +1070,7 @@
       "recording_title": "Music for a Solemnity - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1p4psz5bB4voVUUTESFjNt",
-      "apple_music": "https://music.apple.com/us/album/music-for-a-solemnity-live/1681182666?i=1681183789&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -840,17 +1080,17 @@
       "recording_title": "A Malvern Suite - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5VNh1uQps8zh1GK6rSIb2e",
-      "apple_music": "https://music.apple.com/us/album/a-malvern-suite-live/1681182666?i=1681183796&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
       "division": "6. divisjon",
       "band": "Moss og omegn Janitsjar",
       "result_piece": "Armenian Dances, Part 1",
-      "recording_title": "Armenian Dances: I. Part 1 - Live",
-      "album": "Nm Janitsjar 2023 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1LcF4lgPX9tOopJovxSaCu",
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-live/1681182666?i=1681183631&uo=4"
+      "recording_title": "Armenian Dances - Live",
+      "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0CGoCMusnQtO7wutKcrqVv",
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -860,7 +1100,7 @@
       "recording_title": "Dawn of a New Day - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/7h0n8AiiEuvu7vAnimK4K0",
-      "apple_music": "https://music.apple.com/us/album/dawn-of-a-new-day-live/1681182666?i=1681183793&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -870,7 +1110,7 @@
       "recording_title": "Persis - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6b9uw3Ihnu4oCcE0ymku4p",
-      "apple_music": "https://music.apple.com/us/album/persis-live/1681182666?i=1681183794&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -880,7 +1120,7 @@
       "recording_title": "Prelude, Siciliano and Rondo - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2qe6oZ9txFtcCvhhs5ptlq",
-      "apple_music": "https://music.apple.com/us/album/prelude-siciliano-and-rondo-live/1681182666?i=1681183338&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -890,7 +1130,7 @@
       "recording_title": "Street Tango - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/4u5aWaD4uskfwRufAntttX",
-      "apple_music": "https://music.apple.com/us/album/street-tango-live/1681182666?i=1681183090&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -900,7 +1140,7 @@
       "recording_title": "D-day - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5sEJceG9bpjewVr6mMAdQY",
-      "apple_music": "https://music.apple.com/us/album/d-day-live/1681182666?i=1681183087&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -910,7 +1150,7 @@
       "recording_title": "Eine Kleine Yiddishe Ragmusik - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0PxAJ3IPmpc2CaNRuIo9Oo",
-      "apple_music": "https://music.apple.com/us/album/eine-kleine-yiddishe-ragmusik-live/1681182666?i=1681184269&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -918,9 +1158,9 @@
       "band": "Strinda Ungdomskorps",
       "result_piece": "Tales and Myths of Gothia",
       "recording_title": "Tales and Myths of Gothia - Live",
-      "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4UMoMVQ0swi2ZNLEfSuVS2",
-      "apple_music": "https://music.apple.com/us/album/tales-and-myths-of-gothia-live/1681182666?i=1681183362&uo=4"
+      "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2xUA2neXltPO9gpaP9of58",
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -929,8 +1169,8 @@
       "result_piece": "Street Tango",
       "recording_title": "Street Tango - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4u5aWaD4uskfwRufAntttX",
-      "apple_music": "https://music.apple.com/us/album/street-tango-live/1681182666?i=1681183090&uo=4"
+      "spotify": "https://open.spotify.com/track/2jcFxGDnGD1vir8uA6vWhF",
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -938,9 +1178,9 @@
       "band": "Vålerenga Janitsjarkorps",
       "result_piece": "Tales and Myths of Gothia",
       "recording_title": "Tales and Myths of Gothia - Live",
-      "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4UMoMVQ0swi2ZNLEfSuVS2",
-      "apple_music": "https://music.apple.com/us/album/tales-and-myths-of-gothia-live/1681182666?i=1681183362&uo=4"
+      "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/63i0Bn9xdEgS4F7h5fcmBQ",
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -950,7 +1190,7 @@
       "recording_title": "Pilatus: Mountain of Dragons - Live",
       "album": "Nm Janitsjar 2023 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/6TiDAJWvAeGB4qWeMVdKCD",
-      "apple_music": "https://music.apple.com/us/album/pilatus-mountain-of-dragons-live/1681182666?i=1681184267&uo=4"
+      "apple_music": null
     },
     {
       "year": 2023,
@@ -960,7 +1200,7 @@
       "recording_title": "Beyond Reach - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1G0q9SgAb0rWpJJmCFNKXy",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/beyond-reach-live/1681181340?i=1681182623&uo=4"
     },
     {
       "year": 2023,
@@ -970,7 +1210,7 @@
       "recording_title": "Dwa- Księżyce - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0fv5YJ86HvIztisqhWlV5W",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/dwa-ksi%C4%99%C5%BCyce-live/1681181340?i=1681182645&uo=4"
     },
     {
       "year": 2023,
@@ -980,7 +1220,7 @@
       "recording_title": "Nostalgia - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5feT5fl8XiMGEhEs80cBoF",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/nostalgia-live/1681181340?i=1681182637&uo=4"
     },
     {
       "year": 2023,
@@ -990,7 +1230,17 @@
       "recording_title": "Made in Bergen - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0vrPBFaTHVJ1IAQ2ocQDio",
-      "apple_music": "https://music.apple.com/us/album/made-in-bergen-live/1680806260?i=1680806471&uo=4"
+      "apple_music": "https://music.apple.com/us/album/made-in-bergen-live/1681181340?i=1681181994&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "7. divisjon",
+      "band": "Hegra Hornmusikklag",
+      "result_piece": "Puszta (Four Gypsi Dances)",
+      "recording_title": "Putza - Live",
+      "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0tjKFMSd9AH3X3DoLDSBe1",
+      "apple_music": "https://music.apple.com/us/album/putza-live/1681181340?i=1681181635&uo=4"
     },
     {
       "year": 2023,
@@ -1000,7 +1250,7 @@
       "recording_title": "Aurora Borealis - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1xRcUdPFaavi8tMJvfKlw2",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/aurora-borealis-live/1681181340?i=1681181987&uo=4"
     },
     {
       "year": 2023,
@@ -1010,7 +1260,7 @@
       "recording_title": "Nordlandstoner - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5KzVmwn0rsQNo0QGTe27tP",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/nordlandstoner-live/1681181340?i=1681181642&uo=4"
     },
     {
       "year": 2023,
@@ -1020,7 +1270,7 @@
       "recording_title": "Underlige aftenlufte - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2sebvIOnY25Nk3vh0vC0XN",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/underlige-aftenlufte-live/1681181340?i=1681181653&uo=4"
     },
     {
       "year": 2023,
@@ -1030,7 +1280,7 @@
       "recording_title": "Tales and Myths of Gothia - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/4UMoMVQ0swi2ZNLEfSuVS2",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/tales-and-myths-of-gothia-live/1681181340?i=1681182491&uo=4"
     },
     {
       "year": 2023,
@@ -1040,17 +1290,17 @@
       "recording_title": "Voice of the Vikings - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2xvZyeCwQ0ibkKIynF7RsG",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/voice-of-the-vikings-live/1681181340?i=1681182483&uo=4"
     },
     {
       "year": 2023,
       "division": "7. divisjon",
       "band": "Nidarvoll Ungdomskorps",
       "result_piece": "Norsk Rapsodi nr. 1",
-      "recording_title": "Norsk Rapsodi Nr. 1 - Live",
-      "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4vml3HvFIVRGaJ9jnXznSZ",
-      "apple_music": "https://music.apple.com/us/album/norsk-rapsodi-nr-1-live/1680515141?i=1680515799&uo=4"
+      "recording_title": "Norsk Rapsodi nr. 1 - Live",
+      "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6SZQXtZugvkIu348UJR5Lq",
+      "apple_music": "https://music.apple.com/us/album/norsk-rapsodi-nr-1-live/1681181340?i=1681181633&uo=4"
     },
     {
       "year": 2023,
@@ -1060,7 +1310,7 @@
       "recording_title": "Golden Peak - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/19kkCGzRIOCQoMqynumKiq",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/golden-peak-live/1681181340?i=1681181352&uo=4"
     },
     {
       "year": 2023,
@@ -1070,7 +1320,7 @@
       "recording_title": "Concita for Band - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1cwuejtxNkho05LPYcLAh9",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/concita-for-band-live/1681181340?i=1681182013&uo=4"
     },
     {
       "year": 2023,
@@ -1080,7 +1330,7 @@
       "recording_title": "Journey Through Orion - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1A5geha2HoDpu95hgWvLiw",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/journey-through-orion-live/1681181340?i=1681182288&uo=4"
     },
     {
       "year": 2023,
@@ -1090,7 +1340,7 @@
       "recording_title": "Three Brass Cats: I: Mr Jums - II. Black Sam - III. Borage - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5SNnnEgMOuuM0k6fw8nvel",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/three-brass-cats-i-mr-jums-ii-black-sam-iii-borage-live/1681181340?i=1681182291&uo=4"
     },
     {
       "year": 2023,
@@ -1100,7 +1350,7 @@
       "recording_title": "Utopia - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0sjW42NdwgQViQSrtNEn7K",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/utopia-live/1681181340?i=1681182618&uo=4"
     },
     {
       "year": 2023,
@@ -1110,7 +1360,7 @@
       "recording_title": "Schaffs Mit Mir, Gott - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/2IIEbXGOSKWzrIKX1p4Tvc",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/schaffs-mit-mir-gott-live/1681181340?i=1681182302&uo=4"
     },
     {
       "year": 2023,
@@ -1120,7 +1370,7 @@
       "recording_title": "The Legend of Maracaibo - Live",
       "album": "Nm Janitsjar 2023 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/1adm583ptVFxCD44o7VJk6",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/the-legend-of-maracaibo-live/1681181340?i=1681182478&uo=4"
     },
     {
       "year": 2023,
@@ -1137,10 +1387,10 @@
       "division": "Elite",
       "band": "Bjergsted Blåseensemble",
       "result_piece": "Norsk Rapsodi nr. 1",
-      "recording_title": "Norsk Rapsodi Nr. 1 - Live",
+      "recording_title": "Norsk Rapsodi No. 1 - Live",
       "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4vml3HvFIVRGaJ9jnXznSZ",
-      "apple_music": "https://music.apple.com/us/album/norsk-rapsodi-nr-1-live/1680515141?i=1680515799&uo=4"
+      "spotify": "https://open.spotify.com/track/62SNgYIq8QSCOhAW4nYJFS",
+      "apple_music": "https://music.apple.com/us/album/norsk-rapsodi-no-1-live/1680515141?i=1680515674&uo=4"
     },
     {
       "year": 2023,
@@ -1195,6 +1445,16 @@
     {
       "year": 2023,
       "division": "Elite",
+      "band": "Greåker Musikkorps",
+      "result_piece": "Symphony no. 4",
+      "recording_title": "Symphony No. 4 - Live",
+      "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3gMUdgZ3U7gsghdsYkL05f",
+      "apple_music": "https://music.apple.com/us/album/symphony-no-4-live/1680515141?i=1680515326&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "Elite",
       "band": "Kolbotn Konsertorkester",
       "result_piece": "Cerebral Vortex",
       "recording_title": "Cerebral Vortex - Live",
@@ -1211,6 +1471,16 @@
       "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/2hOJvufmh7Gs74ZTr1VEiV",
       "apple_music": "https://music.apple.com/us/album/det-gamle-kvernhuset-op-204-windband-live/1680515141?i=1680515513&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "Elite",
+      "band": "Kolbotn Konsertorkester",
+      "result_piece": "Redline Tango",
+      "recording_title": "Redline Tango - Live",
+      "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5kvnDssiuvXAfttLGSEAvk",
+      "apple_music": "https://music.apple.com/us/album/redline-tango-live/1680515141?i=1680515533&uo=4"
     },
     {
       "year": 2023,
@@ -1311,6 +1581,16 @@
       "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/5GWA4MsyQdOIBbZGXPaSid",
       "apple_music": "https://music.apple.com/us/album/homenaje-a-joaquin-sorolla-live/1680515141?i=1680515783&uo=4"
+    },
+    {
+      "year": 2023,
+      "division": "Elite",
+      "band": "Strusshamn Musikkforening",
+      "result_piece": "Redline Tango",
+      "recording_title": "Redline Tango - Live",
+      "album": "Nm Janitsjar 2023 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0fJ7wgPN4AyeFZJt4LwKFV",
+      "apple_music": "https://music.apple.com/us/album/redline-tango-live/1680515141?i=1680515779&uo=4"
     }
   ]
 }

--- a/apps/band-positions/public/data/streaming/wind/2024.json
+++ b/apps/band-positions/public/data/streaming/wind/2024.json
@@ -7,9 +7,9 @@
       "division": "1. divisjon",
       "band": "Borge Musikkorps",
       "result_piece": "Divertimento for Band, 4., 5. og 6. sats",
-      "recording_title": "Divertimento for band, Op42: IV, V, VI (Live)",
+      "recording_title": "Divertimento for band, Op42: IV, V, VI - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/33QJtc31DN66AM02vNAmEu",
       "apple_music": "https://music.apple.com/us/album/divertimento-for-band-op42-iv-v-vi-live/1737793406?i=1737793626&uo=4"
     },
     {
@@ -17,9 +17,9 @@
       "division": "1. divisjon",
       "band": "Borge Musikkorps",
       "result_piece": "Konzertmusik Für Blasorchester",
-      "recording_title": "Konzertmusik fûr Blasorchester, Op.41 (Live)",
+      "recording_title": "Konzertmusik fûr Blasorchester, Op.41 - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/2ZBh6XAKwsbBcPiiPuHuFc",
       "apple_music": "https://music.apple.com/us/album/konzertmusik-f%C3%BBr-blasorchester-op-41-live/1737793406?i=1737793623&uo=4"
     },
     {
@@ -27,29 +27,59 @@
       "division": "1. divisjon",
       "band": "Kolbotn Konsertorkester",
       "result_piece": "D'un Soir Triste",
-      "recording_title": "D'un soir triste (Live)",
+      "recording_title": "D´un soir triste - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6aFVkIrBMqu5KB72lATGdu",
       "apple_music": "https://music.apple.com/us/album/dun-soir-triste-live/1737793406?i=1737794032&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "1. divisjon",
+      "band": "Kolbotn Konsertorkester",
+      "result_piece": "Norsk Rapsodi nr. 1",
+      "recording_title": "Rhapsody Norvegienne No. 1 - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6XUcT1hbYq16Er8Tpwb2gv",
+      "apple_music": "https://music.apple.com/us/album/rhapsody-norvegienne-no-1-live/1737793406?i=1737794034&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Kolbu Janitsjarkorps",
       "result_piece": "Equus",
-      "recording_title": "Equus (Live)",
+      "recording_title": "Equus - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/1jwvYcBcGMZpDqiWTt7qjj",
       "apple_music": "https://music.apple.com/us/album/equus-live/1737793406?i=1737794358&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "1. divisjon",
+      "band": "Kolbu Janitsjarkorps",
+      "result_piece": "Fanfare and Choral",
+      "recording_title": "Fanfare og koral - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/12loXN9XQuS1uqZQmYHcJ6",
+      "apple_music": "https://music.apple.com/us/album/fanfare-og-koral-live/1737793406?i=1737794055&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "1. divisjon",
+      "band": "Lørenskog Musikkorps",
+      "result_piece": "Symphony No IV: Bookmarks from Japan",
+      "recording_title": "Bookmarks from Japan - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2kTuRHeSmbmnbRz4ytMIMO",
+      "apple_music": "https://music.apple.com/us/album/bookmarks-from-japan-live/1737793406?i=1737794037&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Nittedal og Hakadal Janitsjar",
       "result_piece": "Symphony for Wind Orchestra",
-      "recording_title": "Symphony for Wind Orchestra - Montage (Live)",
+      "recording_title": "Symphony for Wind Orchestra - Montage - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/2JJ8BQICgwcnBlwjKzHUMv",
       "apple_music": "https://music.apple.com/us/album/symphony-for-wind-orchestra-montage-live/1737793406?i=1737794665&uo=4"
     },
     {
@@ -57,19 +87,19 @@
       "division": "1. divisjon",
       "band": "Os Musikkforening",
       "result_piece": "Armenian Dances, Part 1",
-      "recording_title": "Armenian Dances: 1: Part 1 - Live",
-      "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3hf3Ett70TjCSIiPduhTVE",
-      "apple_music": "https://music.apple.com/us/album/armenian-dances-1-part-1-live/1737790756?i=1737792868&uo=4"
+      "recording_title": "Armenian Dances: I: Part 1 - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5c0aJGtTTJ3U4COGqVydCE",
+      "apple_music": "https://music.apple.com/us/album/armenian-dances-i-part-1-live/1737793406?i=1737794682&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Os Musikkforening",
       "result_piece": "Vesuvius",
-      "recording_title": "Vesuvius (Live)",
+      "recording_title": "Vesuvius - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4sodV8W3Vc0B6ZkXF0JWwz",
       "apple_music": "https://music.apple.com/us/album/vesuvius-live/1737793406?i=1737794678&uo=4"
     },
     {
@@ -77,19 +107,19 @@
       "division": "1. divisjon",
       "band": "Sandefjord Musikkorps",
       "result_piece": "An Gé Fhián",
-      "recording_title": "An Gé Fhiáin (The Wild Goose) - Live",
-      "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4QG5nJNli2Sl6nGT4hChSq",
-      "apple_music": "https://music.apple.com/us/album/an-g%C3%A9-fhi%C3%A1in-the-wild-goose-live/1737790756?i=1737792137&uo=4"
+      "recording_title": "An Gé fhiáin (The wild goose) - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4mTZoMkg8dGJSGVneW5zA9",
+      "apple_music": "https://music.apple.com/us/album/an-g%C3%A9-fhi%C3%A1in-the-wild-goose-live/1737793406?i=1737794668&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Sandefjord Musikkorps",
       "result_piece": "Aurora Awakes",
-      "recording_title": "Aurora Awakes (Live)",
+      "recording_title": "Aurora Awakes - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6rb0d2VuTB0e0MIgzCtIza",
       "apple_music": "https://music.apple.com/us/album/aurora-awakes-live/1737793406?i=1737794675&uo=4"
     },
     {
@@ -97,9 +127,9 @@
       "division": "1. divisjon",
       "band": "Sandvikens Ungdomskorps",
       "result_piece": "Gloriosa",
-      "recording_title": "Gloriosa (Live)",
+      "recording_title": "Gloriosa - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/3OnyUNRgbH6jNRv7mwRu0V",
       "apple_music": "https://music.apple.com/us/album/gloriosa-live/1737793406?i=1737793518&uo=4"
     },
     {
@@ -108,18 +138,18 @@
       "band": "Sarpsborg Janitsjarkorps",
       "result_piece": "Godspeed",
       "recording_title": "Godspeed - Live",
-      "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3cb8fTfc7mxpeIP04QY2P0",
-      "apple_music": "https://music.apple.com/us/album/godspeed-live/1737790756?i=1737791496&uo=4"
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4nuSB1geAJ6KUcKqTnwx1C",
+      "apple_music": "https://music.apple.com/us/album/godspeed-live/1737793406?i=1737794028&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Sarpsborg Janitsjarkorps",
       "result_piece": "Redline Tango",
-      "recording_title": "Redline Tango (Live)",
+      "recording_title": "Redline Tango - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/1SwbniWx1cDP7JAHY0cxHY",
       "apple_music": "https://music.apple.com/us/album/redline-tango-live/1737793406?i=1737793790&uo=4"
     },
     {
@@ -127,19 +157,29 @@
       "division": "1. divisjon",
       "band": "Sarpsborg Janitsjarkorps",
       "result_piece": "Sentimental Pebbles",
-      "recording_title": "Sentimental Pebbles (Live)",
+      "recording_title": "Sentimental Pebbles - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/1YooaqZM5mm5oxRNgceV1p",
       "apple_music": "https://music.apple.com/us/album/sentimental-pebbles-live/1737793406?i=1737793815&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "1. divisjon",
+      "band": "Skjold Nesttun Janitsjar",
+      "result_piece": "From Ancient Times",
+      "recording_title": "From Ancient Times - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5l9R85H5X0rbGF44osz2Sp",
+      "apple_music": "https://music.apple.com/us/album/from-ancient-times-live/1737793406?i=1737794666&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Stavanger Musikkorps av 1919",
       "result_piece": "Magnolia Star",
-      "recording_title": "Magnolia Star (Live)",
+      "recording_title": "Magnolia Star - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/2glLdGdDJewVlhor6Grjsq",
       "apple_music": "https://music.apple.com/us/album/magnolia-star-live/1737793406?i=1737794384&uo=4"
     },
     {
@@ -147,40 +187,110 @@
       "division": "1. divisjon",
       "band": "Stavanger Musikkorps av 1919",
       "result_piece": "The Frozen Cathedral",
-      "recording_title": "The Frozen Cathedral (Live)",
+      "recording_title": "The Frozen Cathedral - Live",
       "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6FwPy1YrnZsaUAaalhQUJu",
       "apple_music": "https://music.apple.com/us/album/the-frozen-cathedral-live/1737793406?i=1737794659&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Vestre Aker Musikkorps",
+      "result_piece": "Concert Overture for Symphonic Band",
+      "recording_title": "Concert ouverture - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2562Qeu192ag8Z3YkuosLM",
+      "apple_music": "https://music.apple.com/us/album/concert-ouverture-live/1737793406?i=1737795409&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "1. divisjon",
+      "band": "Vestre Aker Musikkorps",
       "result_piece": "Incantation and Dance",
-      "recording_title": "Incantation and Dance (Live)",
-      "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/incantation-and-dance-live/1737781717?i=1737782499&uo=4"
+      "recording_title": "Incantation and Dance - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4fjx4XDf2DbOyN65CA5TU4",
+      "apple_music": "https://music.apple.com/us/album/incantation-and-dance-live/1737793406?i=1737795416&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "1. divisjon",
+      "band": "Vestre Aker Musikkorps",
+      "result_piece": "Symphonic Metamorphosis of themes by Carl Maria von Weber, 4. sats March",
+      "recording_title": "Symfoniske metamorfoser: March - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/657NFQAchIIahnaIRjzSPS",
+      "apple_music": "https://music.apple.com/us/album/symfoniske-metamorfoser-march-live/1737793406?i=1737795422&uo=4"
     },
     {
       "year": 2024,
       "division": "1. divisjon",
       "band": "Ådalsbruk Musikkforening",
       "result_piece": "Symphony no. 1",
-      "recording_title": "Symphony no. 1: 1: Gilgamesh - Live",
-      "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3G9FGFnZvvkUEsETrA7O1y",
-      "apple_music": "https://music.apple.com/us/album/symphony-no-1-1-gilgamesh-live/1737790756?i=1737794409&uo=4"
+      "recording_title": "Asgard - Symphony No. 1 - Live",
+      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7t1M0NpCpnBmuXPbL8OKZz",
+      "apple_music": "https://music.apple.com/us/album/asgard-symphony-no-1-live/1737793406?i=1737794376&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Asker Musikkorps",
+      "result_piece": "Stratoscape",
+      "recording_title": "Stratoscape - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4JSuXRf46kVXmGhTZ6HGEj",
+      "apple_music": "https://music.apple.com/us/album/stratoscape-live/1738048279?i=1738049248&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Bispehaugen Ungdomskorps",
+      "result_piece": "Jungla, Poema ambientado en la Selva Africana",
+      "recording_title": "Jungla (Live)",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": null,
+      "apple_music": "https://music.apple.com/us/album/jungla-live/1738048279?i=1738051382&uo=4"
     },
     {
       "year": 2024,
       "division": "2. divisjon",
       "band": "Bjølsen Ungdomskorps",
       "result_piece": "Symphony No IV: Bookmarks from Japan, 1., 2., 4., 5., og 6. sats",
-      "recording_title": "Bookmarks from Japan (Live)",
-      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/bookmarks-from-japan-live/1737793406?i=1737794037&uo=4"
+      "recording_title": "Symphoni No. 4 - Bookmarks from Japan: I, II, IV, V, VI - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/27b95ulRHL2qbqgLmlejH1",
+      "apple_music": "https://music.apple.com/us/album/symphoni-no-4-bookmarks-from-japan-i-ii-iv-v-vi-live/1738048279?i=1738050498&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Drammen Konsertorkester",
+      "result_piece": "Canto d'ommagio",
+      "recording_title": "Canto d´Ommagio - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0W8OVhBJfIRrMa5lzruXWA",
+      "apple_music": "https://music.apple.com/us/album/canto-dommagio-live/1738048279?i=1738048306&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Drammen Konsertorkester",
+      "result_piece": "Tam o'Shanter",
+      "recording_title": "Tam O´Shanter - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1vs1d7kY48sjqjBv2M5cku",
+      "apple_music": "https://music.apple.com/us/album/tam-oshanter-live/1738048279?i=1738048789&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Gjøvik Bykorps",
+      "result_piece": "Battle of Hearts",
+      "recording_title": "Battle of hearts - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1OxVwSMrE84sO7QF7Mx71G",
+      "apple_music": "https://music.apple.com/us/album/battle-of-hearts-live/1738048279?i=1738050510&uo=4"
     },
     {
       "year": 2024,
@@ -188,9 +298,59 @@
       "band": "Hov Musikkorps",
       "result_piece": "Arabesque",
       "recording_title": "Arabesque - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3BwDkNIZgX4etz2rzp1Yd4",
-      "apple_music": null
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7fw2CKB09lJfJU9EA6FWKS",
+      "apple_music": "https://music.apple.com/us/album/arabesque-live/1738048279?i=1738051216&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Hov Musikkorps",
+      "result_piece": "Third Suite for Band",
+      "recording_title": "Third Suite for Band - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3OEG6t7SeV4PLB8nXDDmCz",
+      "apple_music": "https://music.apple.com/us/album/third-suite-for-band-live/1738048279?i=1738051188&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Hovin Musikkorps",
+      "result_piece": "Las Aventuras del Principito",
+      "recording_title": "Las Aventuras del Principito - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1Y7YwLz1tNYptKlRLEbtCz",
+      "apple_music": "https://music.apple.com/us/album/las-aventuras-del-principito-live/1738048279?i=1738051645&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Lungegaardens Musikkorps",
+      "result_piece": "Seinsumarsdraum",
+      "recording_title": "Seinsumarsdraum - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4x2FUqMCBF83g57EoEtuID",
+      "apple_music": "https://music.apple.com/us/album/seinsumarsdraum-live/1738048279?i=1738049260&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Musikklaget Brage",
+      "result_piece": "Firework",
+      "recording_title": "Firework - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3GuxquDfn9Y4GEU6cr9n0R",
+      "apple_music": "https://music.apple.com/us/album/firework-live/1738048279?i=1738048809&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Musikklaget Brage",
+      "result_piece": "Milestones",
+      "recording_title": "Milestones - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1EvBvh6sVVW0WRt8z03k5l",
+      "apple_music": "https://music.apple.com/us/album/milestones-live/1738048279?i=1738049096&uo=4"
     },
     {
       "year": 2024,
@@ -198,18 +358,78 @@
       "band": "Ringsaker Janitjsar",
       "result_piece": "Carnival",
       "recording_title": "Carnival - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2IyTJIZ2Z7MpxXTVIjqRsI",
-      "apple_music": null
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1yx6eorkhNwTZpPtVoghVV",
+      "apple_music": "https://music.apple.com/us/album/carnival-live/1738048279?i=1738049498&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Ringsaker Janitjsar",
+      "result_piece": "Metroplex: Three Postcards from Manhattan",
+      "recording_title": "Metroplex - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1IoCFBHRoLzcmbQV9r6sR4",
+      "apple_music": "https://music.apple.com/us/album/metroplex-live/1738048279?i=1738049482&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Sinsen Konsertorkester",
+      "result_piece": "Colas Breugnon Overture",
+      "recording_title": "Colas Breugnon Overture - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/68Sp7FFGpFTD0MUHguPa5J",
+      "apple_music": "https://music.apple.com/us/album/colas-breugnon-overture-live/1738048279?i=1738050521&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Sinsen Konsertorkester",
+      "result_piece": "Masquerad",
+      "recording_title": "Masquerad - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2QG0AQL215ILluoluVcv7e",
+      "apple_music": "https://music.apple.com/us/album/masquerad-live/1738048279?i=1738050987&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Tromsø Orkesterforenings Janitsjarkorps",
+      "result_piece": "Nord",
+      "recording_title": "Nord - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6h6ebThqdlRqpoDtc087Q8",
+      "apple_music": "https://music.apple.com/us/album/nord-live/1738048279?i=1738050119&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Tønsberg Janitsjarkorps",
+      "result_piece": "Apocalyptic Dreams",
+      "recording_title": "Apocalyptic Dreams - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1eol6J3fSo4PSnqt86i136",
+      "apple_music": "https://music.apple.com/us/album/apocalyptic-dreams-live/1738048279?i=1738050107&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "2. divisjon",
+      "band": "Vestsidens Musikkorps",
+      "result_piece": "Sidus",
+      "recording_title": "Sidus - Live",
+      "album": "Nm Janitsjar 2024 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2pw6CAQW3Tujh8jLzIxhus",
+      "apple_music": "https://music.apple.com/us/album/sidus-live/1738048279?i=1738049899&uo=4"
     },
     {
       "year": 2024,
       "division": "3. divisjon",
       "band": "Aalesunds Ungdomsmusikkorps",
       "result_piece": "Unbroken",
-      "recording_title": "Unbroken (Live)",
+      "recording_title": "Unbroken - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/3xoMogZCi4m6R8OawL79rk",
       "apple_music": "https://music.apple.com/us/album/unbroken-live/1737781717?i=1737783138&uo=4"
     },
     {
@@ -217,29 +437,19 @@
       "division": "3. divisjon",
       "band": "Asker og Bærum Ungdomskorps",
       "result_piece": "Pompeii: The Ruins Know the Long and Magnificent History",
-      "recording_title": "Pompeii - the Ruins Know the Long and Magnificent History (Live)",
+      "recording_title": "Pompeii - the Ruins Know the Long and Magnificent History - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/0agHOM01K6BgwAU7JFI0eQ",
       "apple_music": "https://music.apple.com/us/album/pompeii-the-ruins-know-the-long-and/1737781717?i=1737782851&uo=4"
-    },
-    {
-      "year": 2024,
-      "division": "3. divisjon",
-      "band": "Fet Janitsjar",
-      "result_piece": "Triptych",
-      "recording_title": "Triptych - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/64MZCS504A3q6ieCrJXwQ1",
-      "apple_music": null
     },
     {
       "year": 2024,
       "division": "3. divisjon",
       "band": "Halsen Musikkforening",
       "result_piece": "Lake of the Moon",
-      "recording_title": "Lake of the Moon - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/6ebmU4oZogKQAn7SgZ3DtN",
+      "recording_title": "Lake of the moon - Live",
+      "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5GhjrSWUa6n2zEBwKAwpJ1",
       "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1737781717?i=1737782840&uo=4"
     },
     {
@@ -247,9 +457,9 @@
       "division": "3. divisjon",
       "band": "Hamar Musikkorps",
       "result_piece": "Saga Maligna",
-      "recording_title": "Saga Maligna (Live)",
+      "recording_title": "Saga Maligna - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/7h4PS5VpFDHNb1f20oSRO9",
       "apple_music": "https://music.apple.com/us/album/saga-maligna-live/1737781717?i=1737782479&uo=4"
     },
     {
@@ -257,19 +467,19 @@
       "division": "3. divisjon",
       "band": "Kongsberg Byorkester",
       "result_piece": "Give us this Day",
-      "recording_title": "Give us this day - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/6QBVJSty4wv3EFdvoRY5lj",
-      "apple_music": "https://music.apple.com/us/album/give-us-this-day-live/1737781717?i=1737782858&uo=4"
+      "recording_title": "Give Us This Day - Live",
+      "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0lVrwiCQ75Y1puC2DmNp9G",
+      "apple_music": "https://music.apple.com/us/album/give-us-this-day-live/1737781717?i=1737783183&uo=4"
     },
     {
       "year": 2024,
       "division": "3. divisjon",
       "band": "Moss og omegn Janitsjar",
       "result_piece": "Give us this Day",
-      "recording_title": "Give us this day - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/6QBVJSty4wv3EFdvoRY5lj",
+      "recording_title": "Give Us This Day - Live",
+      "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2z4fjC8O53KAr9apf90n9R",
       "apple_music": "https://music.apple.com/us/album/give-us-this-day-live/1737781717?i=1737782858&uo=4"
     },
     {
@@ -277,9 +487,9 @@
       "division": "3. divisjon",
       "band": "Nes Janitsjarkorps",
       "result_piece": "Headland Fantasy",
-      "recording_title": "Headland Fantasty (Live)",
+      "recording_title": "Headland Fantasty - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/7F4WTMVHdvInfGW4UldPFQ",
       "apple_music": "https://music.apple.com/us/album/headland-fantasty-live/1737781717?i=1737782505&uo=4"
     },
     {
@@ -287,9 +497,9 @@
       "division": "3. divisjon",
       "band": "Sagene Janitsjarkorps",
       "result_piece": "Symphonic Suite",
-      "recording_title": "Symphonic Suite (Live)",
+      "recording_title": "Symphonic Suite - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/1OG9fUHjUwnVVYnWE9n2Em",
       "apple_music": "https://music.apple.com/us/album/symphonic-suite-live/1737781717?i=1737781725&uo=4"
     },
     {
@@ -297,19 +507,9 @@
       "division": "3. divisjon",
       "band": "Sofienberg Musikkorps",
       "result_piece": "Lake of the Moon",
-      "recording_title": "Lake of the Moon - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/6ebmU4oZogKQAn7SgZ3DtN",
-      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1737781717?i=1737782840&uo=4"
-    },
-    {
-      "year": 2024,
-      "division": "3. divisjon",
-      "band": "Stabekk Janitsjarorkester",
-      "result_piece": "Triptych",
-      "recording_title": "Triptych - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/64MZCS504A3q6ieCrJXwQ1",
+      "recording_title": "Lake of the moon - Live",
+      "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5GhjrSWUa6n2zEBwKAwpJ1",
       "apple_music": null
     },
     {
@@ -317,9 +517,9 @@
       "division": "3. divisjon",
       "band": "Strindheim Janitsjar",
       "result_piece": "Incantation and Dance",
-      "recording_title": "Incantation and Dance (Live)",
+      "recording_title": "Incantation and Dance - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/51ofR6c4w5YROxherpMSt7",
       "apple_music": "https://music.apple.com/us/album/incantation-and-dance-live/1737781717?i=1737782499&uo=4"
     },
     {
@@ -327,9 +527,9 @@
       "division": "3. divisjon",
       "band": "Strindheim Janitsjar",
       "result_piece": "Xerxes",
-      "recording_title": "Xerxes (Live)",
+      "recording_title": "Xerxes - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6PWK8KJxZ9bQALQ2H2fZrw",
       "apple_music": "https://music.apple.com/us/album/xerxes-live/1737781717?i=1737782482&uo=4"
     },
     {
@@ -337,9 +537,9 @@
       "division": "3. divisjon",
       "band": "Sykkylven Janitsjarorkester",
       "result_piece": "Banja Luka",
-      "recording_title": "Banja Luka (Live)",
+      "recording_title": "Banja Luka - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/7dL30cRsPOkRUK8BLloMQF",
       "apple_music": "https://music.apple.com/us/album/banja-luka-live/1737781717?i=1737781721&uo=4"
     },
     {
@@ -348,8 +548,8 @@
       "band": "Åsane Musikklag",
       "result_piece": "Compostela",
       "recording_title": "Compostela - Live",
-      "album": "Nm Janitsjar 2024 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3QjnhABzVyiPXG1Lb7B5GA",
+      "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6EqUfpqKsA1dViyKdzXMql",
       "apple_music": "https://music.apple.com/us/album/compostela-live/1737781717?i=1737783179&uo=4"
     },
     {
@@ -357,9 +557,9 @@
       "division": "3. divisjon",
       "band": "Åsane Musikklag",
       "result_piece": "Ignition",
-      "recording_title": "Ignition (Live)",
+      "recording_title": "Ignition - Live",
       "album": "Nm Janitsjar 2024 - 3. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/49RbRZwzGh9gJ844OlN28a",
       "apple_music": "https://music.apple.com/us/album/ignition-live/1737781717?i=1737783170&uo=4"
     },
     {
@@ -787,30 +987,160 @@
       "division": "6. divisjon",
       "band": "Bjørgvin Blåseensemble",
       "result_piece": "Astronauten-Marsch",
-      "recording_title": "Astronauten-Marsch - Live",
-      "album": "Nm Janitsjar 2024 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/0rZBjkcRW58pHBsvjFb4GQ",
-      "apple_music": "https://music.apple.com/us/album/astronauten-marsch-live/1739590005?i=1739591409&uo=4"
+      "recording_title": "Astronauten - Marsch - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4lQZKRM0InJYsDzBOvBbNe",
+      "apple_music": "https://music.apple.com/us/album/astronauten-marsch-live/1737785171?i=1737786068&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Bjørgvin Blåseensemble",
+      "result_piece": "Norwegian Dance",
+      "recording_title": "Norwegian Dance - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5pdTvODma9OpUNe3f7Zkm4",
+      "apple_music": "https://music.apple.com/us/album/norwegian-dance-live/1737785171?i=1737785999&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Bjørgvin Blåseensemble",
+      "result_piece": "Slava!",
+      "recording_title": "Slava! - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3En5CMGWcyTeUxT6qFtkJL",
+      "apple_music": "https://music.apple.com/us/album/slava-live/1737785171?i=1737786590&uo=4"
     },
     {
       "year": 2024,
       "division": "6. divisjon",
       "band": "Drøbak Musikkorps",
       "result_piece": "Lake of the Moon",
-      "recording_title": "Lake of the Moon - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/6ebmU4oZogKQAn7SgZ3DtN",
-      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1737781717?i=1737782840&uo=4"
+      "recording_title": "Lake of the moon - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7d68Z2ffhPxWVdLKZJ86pk",
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1737785171?i=1737786744&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Follebu og Vestre Gausdal Musikkforening",
+      "result_piece": "Golden Peak",
+      "recording_title": "Golden Peak - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1E1d8Q3tuZuzp3CwCk2Wxu",
+      "apple_music": "https://music.apple.com/us/album/golden-peak-live/1737785171?i=1737789720&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Hegra Hornmusikklag",
+      "result_piece": "First Suite in Eb for Military Band, 1. sats, Chaconne",
+      "recording_title": "First Suite in E flat: I: 1. movement - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2Ya2bdM5FUuneyJF52lUGl",
+      "apple_music": "https://music.apple.com/us/album/first-suite-in-e-flat-i-1-movement-live/1737785171?i=1737787224&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Hegra Hornmusikklag",
+      "result_piece": "Yosemite Autumn",
+      "recording_title": "Yosemite Autumn - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3n8Rno3QbTbBXCj94hQtjB",
+      "apple_music": "https://music.apple.com/us/album/yosemite-autumn-live/1737785171?i=1737787587&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Hommelvik Musikkorps",
+      "result_piece": "Prevision",
+      "recording_title": "Prevision - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1F6VRk4u6wu8Vc5Ba9ocER",
+      "apple_music": "https://music.apple.com/us/album/prevision-live/1737785171?i=1737787922&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Jevnaker Ungdomskorps",
+      "result_piece": "Freedom Defended",
+      "recording_title": "Freedom Defended - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1w6xxMiE4QyyZrA5hfpU1t",
+      "apple_music": "https://music.apple.com/us/album/freedom-defended-live/1737785171?i=1737788446&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Jevnaker Ungdomskorps",
+      "result_piece": "Minnen från Holmen",
+      "recording_title": "Minnen från holmen - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5IX7vnkGeYUSrpdErbPN3q",
+      "apple_music": "https://music.apple.com/us/album/minnen-fr%C3%A5n-holmen-live/1737785171?i=1737788432&uo=4"
     },
     {
       "year": 2024,
       "division": "6. divisjon",
       "band": "Kila Musikkforening",
       "result_piece": "Candide Overture",
-      "recording_title": "Concert ouverture (Live)",
-      "album": "Nm Janitsjar 2024 - 1. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/concert-ouverture-live/1737793406?i=1737795409&uo=4"
+      "recording_title": "Overture to candide - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/58qfP3JqgCfqZgJ0FoIsvH",
+      "apple_music": "https://music.apple.com/us/album/overture-to-candide-live/1737785171?i=1737789381&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Kila Musikkforening",
+      "result_piece": "Symphony no. 1, The Lord of the Rings, \"Gandalf\"",
+      "recording_title": "Symphony no. 1 - The Lord of the Rings: I: Gandalf - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7nC2TiSPzA7VrOneGqXMgN",
+      "apple_music": "https://music.apple.com/us/album/symphony-no-1-the-lord-of-the-rings-i-gandalf-live/1737785171?i=1737789399&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Klæbu Musikkorps",
+      "result_piece": "Variations for Band",
+      "recording_title": "Variations for band - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4sxVfKptBQfCy1ADgot1gX",
+      "apple_music": "https://music.apple.com/us/album/variations-for-band-live/1737785171?i=1737785526&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Musikkorpset TEMPO",
+      "result_piece": "The Air Race",
+      "recording_title": "The Air Race - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2zpE2P3tPTejv491UgkC0x",
+      "apple_music": "https://music.apple.com/us/album/the-air-race-live/1737785171?i=1737788761&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Musikkorpset TEMPO",
+      "result_piece": "Veslemøys Sang",
+      "recording_title": "Veslemøys sang - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/13gC9FnfzHT33ThGFWqmXf",
+      "apple_music": "https://music.apple.com/us/album/veslem%C3%B8ys-sang-live/1737785171?i=1737788756&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Namsos Musikkorps",
+      "result_piece": "On the Way to 100 Years",
+      "recording_title": "On the way to 100 years - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7EuWs3N9sFxMCAzwFlrYKH",
+      "apple_music": "https://music.apple.com/us/album/on-the-way-to-100-years-live/1737785171?i=1737787929&uo=4"
     },
     {
       "year": 2024,
@@ -818,19 +1148,59 @@
       "band": "Namsos Musikkorps",
       "result_piece": "Underlige Aftenlufte",
       "recording_title": "Underlige Aftenlufte - Live",
-      "album": "Nm Janitsjar 2024 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/45ruKEMDqzIEG4jw7tlFwa",
-      "apple_music": "https://music.apple.com/us/album/underlige-aftenlufte-live/1739590005?i=1739591395&uo=4"
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6kXrI0SYABvav5oOscLLDU",
+      "apple_music": "https://music.apple.com/us/album/underlige-aftenlufte-live/1737785171?i=1737788418&uo=4"
     },
     {
       "year": 2024,
       "division": "6. divisjon",
       "band": "Nordre Aker Janitsjar",
       "result_piece": "A Springtime Celebration",
-      "recording_title": "Time for celebration - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/7A8S4lTwUCTIKxKQmh0ncb",
-      "apple_music": "https://music.apple.com/us/album/a-symphonic-celebration-live/1737782962?i=1737784272&uo=4"
+      "recording_title": "A Springtime Celebration - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3pb4MbmMPx4b6LnOEAfjSG",
+      "apple_music": "https://music.apple.com/us/album/a-springtime-celebration-live/1737785171?i=1737785512&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Nordre Aker Janitsjar",
+      "result_piece": "New York: 1927",
+      "recording_title": "New York: 1927 - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6oDxJFAIREfertFYB511vT",
+      "apple_music": "https://music.apple.com/us/album/new-york-1927-live/1737785171?i=1737785522&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Skatval Hornmusikklag",
+      "result_piece": "Symphony no. 1, The Lord of the Rings, \"Hobbits\"",
+      "recording_title": "Symphony no. 1 - The Lord of the Rings: V: Hobbits - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4FCqG4a2uGJg6rneSL9QIL",
+      "apple_music": "https://music.apple.com/us/album/symphony-no-1-the-lord-of-the-rings-v-hobbits-live/1737785171?i=1737787219&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Trøgstad Janitsjar",
+      "result_piece": "Cassiopeia",
+      "recording_title": "Cassiopeia - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/42HxfAnpzYfG8a6npmBcfq",
+      "apple_music": "https://music.apple.com/us/album/cassiopeia-live/1737785171?i=1737789051&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Trøgstad Janitsjar",
+      "result_piece": "Hoch Heidecksburg, op. 10",
+      "recording_title": "Hoch Heidecksburg Op. 10 - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1A4vizVeSqECExyi8BbXpX",
+      "apple_music": "https://music.apple.com/us/album/hoch-heidecksburg-op-10-live/1737785171?i=1737789069&uo=4"
     },
     {
       "year": 2024,
@@ -838,18 +1208,28 @@
       "band": "Vålerenga Janitsjarkorps",
       "result_piece": "Eldorado",
       "recording_title": "Eldorado - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1eH2aTLHNxKTTvwOS3rBMo",
-      "apple_music": "https://music.apple.com/us/album/eldorado-live/1737782962?i=1737783810&uo=4"
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0H8WwGoBTWbNi8cHj3VJ6O",
+      "apple_music": "https://music.apple.com/us/album/eldorado-live/1737785171?i=1737787597&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "6. divisjon",
+      "band": "Åndalsnes Musikkforening",
+      "result_piece": "Music for a Solemnity",
+      "recording_title": "Music for a Solemnity - Live",
+      "album": "Nm Janitsjar 2024 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7yxd01MgymOuXt9GQUcCLH",
+      "apple_music": "https://music.apple.com/us/album/music-for-a-solemnity-live/1737785171?i=1737785175&uo=4"
     },
     {
       "year": 2024,
       "division": "7. divisjon",
       "band": "Egersund Musikkorps",
       "result_piece": "A Symphonic Celebration",
-      "recording_title": "A Symphonic Celebration (Live)",
+      "recording_title": "A Symphonic Celebration - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4GPWwxH10s8VQqXwsafBgQ",
       "apple_music": "https://music.apple.com/us/album/a-symphonic-celebration-live/1737782962?i=1737784272&uo=4"
     },
     {
@@ -857,9 +1237,9 @@
       "division": "7. divisjon",
       "band": "Egersund Musikkorps",
       "result_piece": "Mount Everest",
-      "recording_title": "Mount Everest (Live)",
+      "recording_title": "Mount Everest - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4PnIXGUO0LL7CHmTkL1qoU",
       "apple_music": "https://music.apple.com/us/album/mount-everest-live/1737782962?i=1737784637&uo=4"
     },
     {
@@ -867,9 +1247,9 @@
       "division": "7. divisjon",
       "band": "Hennummusikken",
       "result_piece": "Corpo Hennum festivo",
-      "recording_title": "Corpo Hennum festivo (Live)",
+      "recording_title": "Corpo Hennum festivo - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/7DQwirtwuFtrJIIPqRJr5q",
       "apple_music": "https://music.apple.com/us/album/corpo-hennum-festivo-live/1737782962?i=1737783818&uo=4"
     },
     {
@@ -878,8 +1258,8 @@
       "band": "Hennummusikken",
       "result_piece": "Eldorado",
       "recording_title": "Eldorado - Live",
-      "album": "Nm Janitsjar 2024 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1eH2aTLHNxKTTvwOS3rBMo",
+      "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4z7aohArxA3F88cE2YuURN",
       "apple_music": "https://music.apple.com/us/album/eldorado-live/1737782962?i=1737783810&uo=4"
     },
     {
@@ -887,9 +1267,9 @@
       "division": "7. divisjon",
       "band": "Lier og Drammen Ungdomskorps",
       "result_piece": "Concerto d’Amore",
-      "recording_title": "Concerto D'Amore (Live)",
+      "recording_title": "Concerto D´Amore - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6oXA3stJUQRr9p8hTaxal5",
       "apple_music": "https://music.apple.com/us/album/concerto-damore-live/1737782962?i=1737784944&uo=4"
     },
     {
@@ -897,9 +1277,9 @@
       "division": "7. divisjon",
       "band": "Lier og Drammen Ungdomskorps",
       "result_piece": "Highlights from the Greatest Showman",
-      "recording_title": "Highlights from the Greatest Showman (Live)",
+      "recording_title": "Highlights from the Greatest Showman - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4f8K7xFrYaxU77ehB7yclY",
       "apple_music": "https://music.apple.com/us/album/highlights-from-the-greatest-showman-live/1737782962?i=1737784663&uo=4"
     },
     {
@@ -907,19 +1287,19 @@
       "division": "7. divisjon",
       "band": "Musikklaget Kornetten",
       "result_piece": "Overture to a new Age",
-      "recording_title": "Overture Op. 2 - Live",
-      "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2ykMprkin0cJUglvfLjWWW",
-      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age-live/1737782962?i=1737784270&uo=4"
+      "recording_title": "Overture to a new age - Live",
+      "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0vb7hyOQwHThPDgUIEihJb",
+      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age-live/1737782962?i=1737784639&uo=4"
     },
     {
       "year": 2024,
       "division": "7. divisjon",
       "band": "Musikklaget Laat",
       "result_piece": "Another Way Home",
-      "recording_title": "Another Way Home (Live)",
+      "recording_title": "Another Way Home - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/2Z28U53oE0EPJDxTu9ihIP",
       "apple_music": "https://music.apple.com/us/album/another-way-home-live/1737782962?i=1737783531&uo=4"
     },
     {
@@ -927,9 +1307,9 @@
       "division": "7. divisjon",
       "band": "Musikklaget Laat",
       "result_piece": "Fanfare for an Occasion",
-      "recording_title": "Fanfare for an Occasion (Live)",
+      "recording_title": "Fanfare for an Occasion - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/3xI46yL8QYHPocctAU4iic",
       "apple_music": "https://music.apple.com/us/album/fanfare-for-an-occasion-live/1737782962?i=1737783387&uo=4"
     },
     {
@@ -937,9 +1317,9 @@
       "division": "7. divisjon",
       "band": "Musikklaget Laat",
       "result_piece": "They Solemnly Served",
-      "recording_title": "They Solemnly Served (Live)",
+      "recording_title": "They Solemnly Served - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6WQLuwEAb2iNanmxJ01i96",
       "apple_music": "https://music.apple.com/us/album/they-solemnly-served-live/1737782962?i=1737783527&uo=4"
     },
     {
@@ -947,19 +1327,19 @@
       "division": "7. divisjon",
       "band": "Nørvøy Ungdomskorps",
       "result_piece": "Compostela",
-      "recording_title": "Compostela - Live",
-      "album": "Nm Janitsjar 2024 - 5. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3QjnhABzVyiPXG1Lb7B5GA",
-      "apple_music": "https://music.apple.com/us/album/compostela-live/1737781717?i=1737783179&uo=4"
+      "recording_title": "Compostela - The Way of St James - Live",
+      "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4c1eXZgRDIx8vkj8GaxIFr",
+      "apple_music": "https://music.apple.com/us/album/compostela-the-way-of-st-james-live/1737782962?i=1737783826&uo=4"
     },
     {
       "year": 2024,
       "division": "7. divisjon",
       "band": "Søndre Nittedal Veterankorps",
       "result_piece": "Merlin",
-      "recording_title": "Merlin (Live)",
+      "recording_title": "Merlin - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4FizF6updrmN56NnXr5tcL",
       "apple_music": "https://music.apple.com/us/album/merlin-live/1737782962?i=1737784075&uo=4"
     },
     {
@@ -967,9 +1347,9 @@
       "division": "7. divisjon",
       "band": "Søndre Nittedal Veterankorps",
       "result_piece": "Novena",
-      "recording_title": "Novena (Live)",
+      "recording_title": "Novena - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/6I2Zgip0CX1cUtGI1cpzZH",
       "apple_music": "https://music.apple.com/us/album/novena-live/1737782962?i=1737784253&uo=4"
     },
     {
@@ -977,9 +1357,9 @@
       "division": "7. divisjon",
       "band": "TUBE",
       "result_piece": "Christian Daae på setra",
-      "recording_title": "Christian Daae på setra (Live)",
+      "recording_title": "Christian Daae på setra - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/5FB6prrddY6EpBXO1X0MAc",
       "apple_music": "https://music.apple.com/us/album/christian-daae-p%C3%A5-setra-live/1737782962?i=1737784953&uo=4"
     },
     {
@@ -987,9 +1367,9 @@
       "division": "7. divisjon",
       "band": "Tretten Musikkforening",
       "result_piece": "Ammerland",
-      "recording_title": "Ammerland (Live)",
+      "recording_title": "Ammerland - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/4j5R3FEOYnWbDntGeHSJRJ",
       "apple_music": "https://music.apple.com/us/album/ammerland-live/1737782962?i=1737783764&uo=4"
     },
     {
@@ -997,9 +1377,9 @@
       "division": "7. divisjon",
       "band": "Tretten Musikkforening",
       "result_piece": "The Last Letter from Murdoch",
-      "recording_title": "The last letter from Murdoch (Live)",
+      "recording_title": "The last letter from Murdoch - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/5OsHRdpRU6BBFDTN4dIFdS",
       "apple_music": "https://music.apple.com/us/album/the-last-letter-from-murdoch-live/1737782962?i=1737783801&uo=4"
     },
     {
@@ -1007,9 +1387,9 @@
       "division": "7. divisjon",
       "band": "Valldal Hornmusikklag",
       "result_piece": "The Flood",
-      "recording_title": "The Flood (Live)",
+      "recording_title": "The Flood - Live",
       "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
-      "spotify": null,
+      "spotify": "https://open.spotify.com/track/2kBeF2fwfGvxKJ16975CjM",
       "apple_music": "https://music.apple.com/us/album/the-flood-live/1737782962?i=1737784262&uo=4"
     },
     {
@@ -1017,9 +1397,9 @@
       "division": "7. divisjon",
       "band": "Vang Musikkforening",
       "result_piece": "Overture to a new Age",
-      "recording_title": "Overture Op. 2 - Live",
-      "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2ykMprkin0cJUglvfLjWWW",
+      "recording_title": "Overture to a new Age - Live",
+      "album": "Nm Janitsjar 2024 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6HOE94A6AzRUejLb6tj52B",
       "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age-live/1737782962?i=1737784270&uo=4"
     },
     {
@@ -1045,6 +1425,56 @@
     {
       "year": 2024,
       "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "Vårofferet",
+      "recording_title": "The Rite of Spring (Live)",
+      "album": "NM Janitsjar 2024 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5BChs0DHLaQzUUsuzPKSWt?si=2577c646aaa54419",
+      "apple_music": "https://music.apple.com/no/album/the-rite-of-spring-live/1737790756?i=1737793781"
+    },
+    {
+      "year": 2024,
+      "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "Vårofferet",
+      "recording_title": "The Rite of Spring (Live)",
+      "album": "NM Janitsjar 2024 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5BChs0DHLaQzUUsuzPKSWt?si=2577c646aaa54419",
+      "apple_music": "https://music.apple.com/no/album/the-rite-of-spring-live/1737790756?i=1737793781"
+    },
+    {
+      "year": 2024,
+      "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "Vårofferet",
+      "recording_title": "The Rite of Spring (Live)",
+      "album": "NM Janitsjar 2024 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5BChs0DHLaQzUUsuzPKSWt?si=2577c646aaa54419",
+      "apple_music": "https://music.apple.com/no/album/the-rite-of-spring-live/1737790756?i=1737793781"
+    },
+    {
+      "year": 2024,
+      "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "Vårofferet",
+      "recording_title": "The Rite of Spring (Live)",
+      "album": "NM Janitsjar 2024 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5BChs0DHLaQzUUsuzPKSWt?si=2577c646aaa54419",
+      "apple_music": "https://music.apple.com/no/album/the-rite-of-spring-live/1737790756?i=1737793781"
+    },
+    {
+      "year": 2024,
+      "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "result_piece": "Vårofferet",
+      "recording_title": "The Rite of Spring (Live)",
+      "album": "NM Janitsjar 2024 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5BChs0DHLaQzUUsuzPKSWt?si=2577c646aaa54419",
+      "apple_music": "https://music.apple.com/no/album/the-rite-of-spring-live/1737790756?i=1737793781"
+    },
+    {
+      "year": 2024,
+      "division": "Elite",
       "band": "Dragefjellets Musikkorps Bergen",
       "result_piece": "Armenian Dances, Part 1",
       "recording_title": "Armenian Dances: 1: Part 1 - Live",
@@ -1060,7 +1490,7 @@
       "recording_title": "Dirty Dancing for Large Wind Ensemble - Live",
       "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/5rmLmXF7kRvHZ8UcNMBieY",
-      "apple_music": "https://music.apple.com/us/album/dirty-dancing-live/1737790756?i=1737793270&uo=4"
+      "apple_music": "https://music.apple.com/us/album/dirty-dancing-for-large-wind-ensemble-live/1737790756?i=1737792885&uo=4"
     },
     {
       "year": 2024,
@@ -1160,16 +1590,26 @@
       "recording_title": "Svit ur Bergakungen - Live",
       "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/0oRHa7wnxeXkBUMP7B92E3",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/svit-ur-bergakungen-live/1737790756?i=1737794255&uo=4"
+    },
+    {
+      "year": 2024,
+      "division": "Elite",
+      "band": "Opus 82",
+      "result_piece": "Ouverture, op. 2",
+      "recording_title": "Overture Op. 2 - Live",
+      "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2ykMprkin0cJUglvfLjWWW",
+      "apple_music": "https://music.apple.com/us/album/overture-op-2-live/1737790756?i=1737794061&uo=4"
     },
     {
       "year": 2024,
       "division": "Elite",
       "band": "Strusshamn Musikkforening",
       "result_piece": "Dirty Dancing",
-      "recording_title": "Dirty Dancing for Large Wind Ensemble - Live",
+      "recording_title": "Dirty Dancing - Live",
       "album": "Nm Janitsjar 2024 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/5rmLmXF7kRvHZ8UcNMBieY",
+      "spotify": "https://open.spotify.com/track/4jkuiveDeUgoYQGH99ugzZ",
       "apple_music": "https://music.apple.com/us/album/dirty-dancing-live/1737790756?i=1737793270&uo=4"
     },
     {

--- a/apps/band-positions/public/data/streaming/wind/2025.json
+++ b/apps/band-positions/public/data/streaming/wind/2025.json
@@ -46,6 +46,16 @@
       "year": 2025,
       "division": "1. divisjon",
       "band": "Kolbotn Konsertorkester",
+      "result_piece": "Fest-Overture, Op. 26",
+      "recording_title": "Fest- Ouvertyre - Live",
+      "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5FHxVI38qGsIZunbl0qpze",
+      "apple_music": "https://music.apple.com/us/album/fest-ouvertyre-live/1808651334?i=1808651349&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "1. divisjon",
+      "band": "Kolbotn Konsertorkester",
       "result_piece": "Variations for Wind Band",
       "recording_title": "Variations for wind band - Live",
       "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
@@ -95,6 +105,16 @@
     {
       "year": 2025,
       "division": "1. divisjon",
+      "band": "Os Musikkforening",
+      "result_piece": "Symphony No IV: Bookmarks from Japan",
+      "recording_title": "Bookmarks from Japan - Live",
+      "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2e52QUo2h4tLUd913RWZjl",
+      "apple_music": "https://music.apple.com/us/album/bookmarks-from-japan-live/1808651334?i=1808651749&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "1. divisjon",
       "band": "Sandefjord Musikkorps",
       "result_piece": "Fanfare and Choral",
       "recording_title": "Fanfare og koral - Live",
@@ -109,8 +129,8 @@
       "result_piece": "Traveler",
       "recording_title": "Traveler - Live",
       "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/0QfcFB9QDSWxosHBh1uii5",
-      "apple_music": "https://music.apple.com/us/album/traveler-live/1808651334?i=1808651551&uo=4"
+      "spotify": "https://open.spotify.com/track/02T37TSPlavZhvk1ZZjuGm",
+      "apple_music": "https://music.apple.com/us/album/traveler-live/1808651334?i=1808652419&uo=4"
     },
     {
       "year": 2025,
@@ -157,10 +177,10 @@
       "division": "1. divisjon",
       "band": "Strusshamn Musikkforening",
       "result_piece": "Firefly",
-      "recording_title": "Firefly - Live",
+      "recording_title": "Firefly - for Sophia and Nyla - Live",
       "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/0mfTZELhCC4HwLQxphxy8z",
-      "apple_music": "https://music.apple.com/us/album/firefly-live/1808651334?i=1808651722&uo=4"
+      "spotify": "https://open.spotify.com/track/78WJYkpnAp8lsoFpYwczWv",
+      "apple_music": "https://music.apple.com/us/album/firefly-for-sophia-and-nyla-live/1808651334?i=1808651985&uo=4"
     },
     {
       "year": 2025,
@@ -169,8 +189,8 @@
       "result_piece": "Fraternity",
       "recording_title": "Fraternity - Live",
       "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3pUL29AT4Tr9qpYcD8myqJ",
-      "apple_music": "https://music.apple.com/us/album/fraternity-live/1808651334?i=1808651565&uo=4"
+      "spotify": "https://open.spotify.com/track/13SFoQ2fIYLs0JAly8kyvk",
+      "apple_music": "https://music.apple.com/us/album/fraternity-live/1808651334?i=1808652143&uo=4"
     },
     {
       "year": 2025,
@@ -237,9 +257,9 @@
       "division": "2. divisjon",
       "band": "Aalesunds Ungdomsmusikkorps",
       "result_piece": "Ride",
-      "recording_title": "El jardin de las hespérides - Live",
-      "album": "Nm Janitsjar 2025 - Elitedivisjon (Live)",
-      "spotify": "https://open.spotify.com/track/4wn8dQ9PbdUZeCPboEceYk",
+      "recording_title": "Ride - Live",
+      "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6YX5Gwcm4JRSBwqhlSVg3M",
       "apple_music": "https://music.apple.com/us/album/ride-live/1808655359?i=1808656163&uo=4"
     },
     {
@@ -257,10 +277,10 @@
       "division": "2. divisjon",
       "band": "Asker og Bærum Ungdomskorps",
       "result_piece": "Symphony No IV: Bookmarks from Japan, 1., 2., 4., 5., og 6. sats",
-      "recording_title": "Bookmarks from Japan (Live)",
-      "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/bookmarks-from-japan-live/1808651334?i=1808651749&uo=4"
+      "recording_title": "Bookmarks from Japan: I, II, IV, V, VI - Live",
+      "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/25vbBJh31SIbg19Yna8DHO",
+      "apple_music": "https://music.apple.com/us/album/bookmarks-from-japan-i-ii-iv-v-vi-live/1808655359?i=1808656323&uo=4"
     },
     {
       "year": 2025,
@@ -309,8 +329,8 @@
       "result_piece": "Sidus",
       "recording_title": "Sidus - Live",
       "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1ylq9fzl24JiuhppyqmpFD",
-      "apple_music": "https://music.apple.com/us/album/sidus-live/1808655359?i=1808656587&uo=4"
+      "spotify": "https://open.spotify.com/track/3RohBUwZjYxsR08GBsvpzn",
+      "apple_music": "https://music.apple.com/us/album/sidus-live/1808655359?i=1808656599&uo=4"
     },
     {
       "year": 2025,
@@ -340,7 +360,7 @@
       "recording_title": "Triptych - Live",
       "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0YHbC8DApKnrUdpLl21F5H",
-      "apple_music": "https://music.apple.com/us/album/triptych-live/1808652240?i=1808652614&uo=4"
+      "apple_music": "https://music.apple.com/us/album/triptych-live/1808655359?i=1808655623&uo=4"
     },
     {
       "year": 2025,
@@ -360,7 +380,7 @@
       "recording_title": "Lake of the Moon - Live",
       "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/75UKX8SlCp1y6Sivzw7upM",
-      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1808652240?i=1808652606&uo=4"
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1808655359?i=1808655642&uo=4"
     },
     {
       "year": 2025,
@@ -370,7 +390,7 @@
       "recording_title": "Karneval i Paris - Live",
       "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5OYkpvCaL4MtF2iuIRfcGS",
-      "apple_music": "https://music.apple.com/us/album/carnival-live/1808651177?i=1808651546&uo=4"
+      "apple_music": null
     },
     {
       "year": 2025,
@@ -380,7 +400,17 @@
       "recording_title": "I fred bland träden bo - Live",
       "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/3g9RNxXsUsbsHnYKD6bYcO",
-      "apple_music": "https://music.apple.com/us/album/i-fred-bland-tr%C3%A4den-bo-live/1808655359?i=1808655975&uo=4"
+      "apple_music": null
+    },
+    {
+      "year": 2025,
+      "division": "2. divisjon",
+      "band": "Sinsen Konsertorkester",
+      "result_piece": "Ballet Suite nr 5, The Bolt (1. Overture, 6. Dance of the Colonial Bondswoman, 8. General Dance and Apotheosis)",
+      "recording_title": "Ballesuite No. 5: I: Overture, VI: Dance of the Bondswoman, VIII: Generel Dance and Apotheosis - Live",
+      "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0olazGy4zHPMw4PZdrWOs6",
+      "apple_music": "https://music.apple.com/us/album/dance-of-the-tumblers-live/1808655359?i=1808656609&uo=4"
     },
     {
       "year": 2025,
@@ -451,6 +481,16 @@
       "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/5jogQYFph3opXezpuZoxhk",
       "apple_music": "https://music.apple.com/us/album/lux-futura-live/1808655359?i=1808655620&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "3. divisjon",
+      "band": "Bodø Harmonimusikk",
+      "result_piece": "Childrens March",
+      "recording_title": "Children´s March \"Over the hills and far away\" - Live",
+      "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2q0vsZNhTOGO3TePmP8xL2",
+      "apple_music": "https://music.apple.com/us/album/childrens-march-over-the-hills-and-far-away-live/1808651177?i=1808651970&uo=4"
     },
     {
       "year": 2025,
@@ -545,6 +585,16 @@
     {
       "year": 2025,
       "division": "3. divisjon",
+      "band": "Lørenskog Blåseensemble",
+      "result_piece": "Symphony No. 9 \"The New World\", 4. sats Finale",
+      "recording_title": "The new world symphony: Finale - Live",
+      "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6OvrrHw8QuVnWLxHPQ2Sjh",
+      "apple_music": "https://music.apple.com/us/album/the-new-world-symphony-finale-live/1808651177?i=1808652155&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "3. divisjon",
       "band": "Nes Janitsjarkorps",
       "result_piece": "The White Deer",
       "recording_title": "The White Deer - Live",
@@ -586,6 +636,16 @@
       "year": 2025,
       "division": "3. divisjon",
       "band": "Skedsmo Janitsjarorkester",
+      "result_piece": "Ignition",
+      "recording_title": "Ignition - Live",
+      "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0LQalUanHsnuSOY8qSDdhv",
+      "apple_music": "https://music.apple.com/us/album/ignition-live/1808651177?i=1808651354&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "3. divisjon",
+      "band": "Skedsmo Janitsjarorkester",
       "result_piece": "With Heart and Voice",
       "recording_title": "With heart and voice - Live",
       "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
@@ -605,12 +665,22 @@
     {
       "year": 2025,
       "division": "3. divisjon",
+      "band": "Strindheim Janitsjar",
+      "result_piece": "Symphony No IV: Bookmarks from Japan, 1., 2., 4. og 6. sats",
+      "recording_title": "Bookmarks from Japan: I, II, IV, VI - Live",
+      "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5vA9he5sBJ3ooBpBS7VsAn",
+      "apple_music": "https://music.apple.com/us/album/bookmarks-from-japan-i-ii-iv-vi-live/1808651177?i=1808652150&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "3. divisjon",
       "band": "Åsane Musikklag",
       "result_piece": "Banja Luka",
       "recording_title": "Banja Luka - Live",
       "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2mntFI7JMZF8ZEetmJrs5F",
-      "apple_music": "https://music.apple.com/us/album/banja-luka-live/1808651177?i=1808651742&uo=4"
+      "spotify": "https://open.spotify.com/track/69R3K6UB1hzc763zPwsTIf",
+      "apple_music": "https://music.apple.com/us/album/banja-luka-live/1808651177?i=1808651960&uo=4"
     },
     {
       "year": 2025,
@@ -619,8 +689,8 @@
       "result_piece": "Compostela",
       "recording_title": "Compostela - Live",
       "album": "Nm Janitsjar 2025 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/3F0HgsFNWLUrkRhw96llmy",
-      "apple_music": "https://music.apple.com/us/album/compostela-live/1808652240?i=1808652597&uo=4"
+      "spotify": "https://open.spotify.com/track/1OQLmnNM3gFJjMKUBQTSV3",
+      "apple_music": "https://music.apple.com/us/album/compostela-live/1808652240?i=1808652991&uo=4"
     },
     {
       "year": 2025,
@@ -769,8 +839,8 @@
       "result_piece": "Lake of the Moon",
       "recording_title": "Lake of the Moon - Live",
       "album": "Nm Janitsjar 2025 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1pfiaQlQ4yaKs9k23CJg3u",
-      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1808652240?i=1808652606&uo=4"
+      "spotify": "https://open.spotify.com/track/09zCdnmYOfZJzDufyI3Z6K",
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1808652240?i=1808653004&uo=4"
     },
     {
       "year": 2025,
@@ -779,8 +849,8 @@
       "result_piece": "Third Suite for Band (Scenes de Ballet)",
       "recording_title": "Third Suite for Band - Live",
       "album": "Nm Janitsjar 2025 - 4. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/5xKd9KQJxNDVYQiXNhT4II",
-      "apple_music": "https://music.apple.com/us/album/third-suite-for-band-live/1808652240?i=1808652246&uo=4"
+      "spotify": "https://open.spotify.com/track/6mYuk9odW9OwlK8nbyAWyS",
+      "apple_music": "https://music.apple.com/us/album/third-suite-for-band-live/1808652240?i=1808652594&uo=4"
     },
     {
       "year": 2025,
@@ -845,12 +915,92 @@
     {
       "year": 2025,
       "division": "5. divisjon",
+      "band": "Byåsen Musikkorps",
+      "result_piece": "Black Gold",
+      "recording_title": "Black Gold - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/4OEKi8ZIv0X5N00vSS7RDA",
+      "apple_music": "https://music.apple.com/us/album/black-gold-live/1808651247?i=1808651268&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Bømlo Janitsjar",
+      "result_piece": "Black Gold",
+      "recording_title": "Black Gold - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1cLlCTidjEiCmiiXY51DwY",
+      "apple_music": "https://music.apple.com/us/album/black-gold-live/1808651247?i=1808651259&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
       "band": "Eina Musikkforening",
       "result_piece": "Banja Luka",
       "recording_title": "Banja Luka - Live",
-      "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2mntFI7JMZF8ZEetmJrs5F",
-      "apple_music": "https://music.apple.com/us/album/banja-luka-live/1808651177?i=1808651742&uo=4"
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3NMREnKenLAGw0m3Q4RXUu",
+      "apple_music": "https://music.apple.com/us/album/banja-luka-live/1808651247?i=1808651263&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Hommelvik Musikkorps",
+      "result_piece": "Excalibur",
+      "recording_title": "Excalibur - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0UVkTzMxsWAenWqSNWn8zA",
+      "apple_music": "https://music.apple.com/us/album/excalibur-live/1808651247?i=1808652002&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Hønefoss Ungdomskorps",
+      "result_piece": "Floating Flags",
+      "recording_title": "Floating Flags - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5HLeAHBlxycIR4yI9OvCnu",
+      "apple_music": "https://music.apple.com/us/album/floating-flags-live/1808651247?i=1808651442&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Klæbu Musikkorps",
+      "result_piece": "Prelude to a Celebration",
+      "recording_title": "Prelude to a Celebration - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5q3r5jjBCL0ReNoNhRdw8B",
+      "apple_music": "https://music.apple.com/us/album/prelude-to-a-celebration-live/1808651247?i=1808651434&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Klæbu Musikkorps",
+      "result_piece": "Saint and the City",
+      "recording_title": "The Saint and The City - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1IrFeT2A3rCU2KtB9dfSYq",
+      "apple_music": "https://music.apple.com/us/album/the-saint-and-the-city-live/1808651247?i=1808651425&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Lier og Drammen Ungdomskorps",
+      "result_piece": "Bunch O'Bones",
+      "recording_title": "Bunch O´Bones - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2cwe9aIuvG0MrOdIHkpE4B",
+      "apple_music": "https://music.apple.com/us/album/bunch-obones-live/1808651247?i=1808651444&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Lier og Drammen Ungdomskorps",
+      "result_piece": "Noah’s Ark",
+      "recording_title": "Noah´s Ark - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0ms74W1KiVaSVqaGRbaihL",
+      "apple_music": "https://music.apple.com/us/album/noahs-ark-live/1808651247?i=1808651448&uo=4"
     },
     {
       "year": 2025,
@@ -858,39 +1008,59 @@
       "band": "Modum Janitsjar",
       "result_piece": "Second Suite for Band",
       "recording_title": "Second Suite for Band - Live",
-      "album": "Nm Janitsjar 2025 - 3. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1fGuenp0yurbnF3wXrsVlu",
-      "apple_music": "https://music.apple.com/us/album/second-suite-for-band-live/1808651177?i=1808651976&uo=4"
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/03yDDatCyHayqHAKuGuA3g",
+      "apple_music": "https://music.apple.com/us/album/second-suite-for-band-live/1808651247?i=1808651804&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Musikklaget Kornetten",
+      "result_piece": "Utopia",
+      "recording_title": "Utopia - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2Zfd7wT21dPi7LZ7Ojl2IS",
+      "apple_music": "https://music.apple.com/us/album/utopia-live/1808651247?i=1808651666&uo=4"
     },
     {
       "year": 2025,
       "division": "5. divisjon",
       "band": "Nidarvoll Ungdomskorps",
       "result_piece": "Angels in the Architecture",
-      "recording_title": "Angels in The Architecture - Live",
-      "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/2zuuyNOst4ysA1ShQI2M1z",
-      "apple_music": "https://music.apple.com/us/album/angels-in-the-architecture-live/1808651334?i=1808651732&uo=4"
+      "recording_title": "Angels in the Architecture - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/49GHF6O7P561dhL0Juu1lY",
+      "apple_music": "https://music.apple.com/us/album/angels-in-the-architecture-live/1808651247?i=1808652075&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Rælingen Musikklag",
+      "result_piece": "Crown Him With Many Crowns",
+      "recording_title": "Crown him with many crowns - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/2h0eXF3khCOTMJA8oVkNR8",
+      "apple_music": "https://music.apple.com/us/album/crown-him-with-many-crowns-live/1808651247?i=1808652007&uo=4"
     },
     {
       "year": 2025,
       "division": "5. divisjon",
       "band": "Rælingen Musikklag",
       "result_piece": "Of Castles and Legends",
-      "recording_title": "Tales and Legends - Live",
-      "album": "Nm Janitsjar 2025 - 1. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/6XPbbNTTdabI2vltPISc3h",
-      "apple_music": "https://music.apple.com/us/album/tales-and-legends-live/1808651334?i=1808651340&uo=4"
+      "recording_title": "Of Castles and Legends - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7p1KBboP7HjtTP29U3qJgN",
+      "apple_music": "https://music.apple.com/us/album/of-castles-and-legends-live/1808651247?i=1808652062&uo=4"
     },
     {
       "year": 2025,
       "division": "5. divisjon",
       "band": "Strinda Ungdomskorps",
       "result_piece": "Festsodd: Divertimento for Korps",
-      "recording_title": "Divertimento (Live)",
-      "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
-      "spotify": null,
-      "apple_music": "https://music.apple.com/us/album/divertimento-live/1808655359?i=1808655631&uo=4"
+      "recording_title": "Festsodd: Divertimento for korps - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5dcoP3pcxRkItOmWxt8blj",
+      "apple_music": "https://music.apple.com/us/album/festsodd-divertimento-for-korps-live/1808651247?i=1808652069&uo=4"
     },
     {
       "year": 2025,
@@ -898,9 +1068,39 @@
       "band": "Tolga-Os Janitsjar",
       "result_piece": "Lake of the Moon",
       "recording_title": "Lake of the Moon - Live",
-      "album": "Nm Janitsjar 2025 - 2. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/75UKX8SlCp1y6Sivzw7upM",
-      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1808652240?i=1808652606&uo=4"
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3n3BSTgzsBtFr0isLNWkNE",
+      "apple_music": "https://music.apple.com/us/album/lake-of-the-moon-live/1808651247?i=1808651680&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Vålerenga Janitsjarkorps",
+      "result_piece": "Hispanola",
+      "recording_title": "Hispaniola - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/7HV25d9P456bPQuMwTel0W",
+      "apple_music": "https://music.apple.com/us/album/hispaniola-live/1808651247?i=1808651787&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Ås og Vestby Musikkorps",
+      "result_piece": "Hispanola",
+      "recording_title": "Hispaniola - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1D0yltMEn0xKMLsYjsuFQM",
+      "apple_music": "https://music.apple.com/us/album/hispaniola-live/1808651247?i=1808651993&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "5. divisjon",
+      "band": "Østensjø Janitsjar",
+      "result_piece": "Hispanola",
+      "recording_title": "Hispaniola - Live",
+      "album": "Nm Janitsjar 2025 - 5. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/243TDcPWBO4PVFnn9fKHTo",
+      "apple_music": "https://music.apple.com/us/album/hispaniola-live/1808651247?i=1808651781&uo=4"
     },
     {
       "year": 2025,
@@ -947,10 +1147,10 @@
       "division": "6. divisjon",
       "band": "Jevnaker Ungdomskorps",
       "result_piece": "Overture to a new Age",
-      "recording_title": "Overture to a New Age - Live",
+      "recording_title": "Overture to a new age - Live",
       "album": "Nm Janitsjar 2025 - 6. divisjon (Live)",
-      "spotify": "https://open.spotify.com/track/1EhEuBKcglrqDAUxBjzp0f",
-      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age-live/1808661166?i=1808661930&uo=4"
+      "spotify": "https://open.spotify.com/track/1nCFiiJ3DkkBFriLDxxSVw",
+      "apple_music": "https://music.apple.com/us/album/overture-to-a-new-age-live/1808661166?i=1808662674&uo=4"
     },
     {
       "year": 2025,
@@ -1005,6 +1205,16 @@
     {
       "year": 2025,
       "division": "6. divisjon",
+      "band": "Skatval Hornmusikklag",
+      "result_piece": "Golden Peak",
+      "recording_title": "Golden Peak - Live",
+      "album": "Nm Janitsjar 2025 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0xbfGBXxcQIL6xIaHq7cOc",
+      "apple_music": "https://music.apple.com/us/album/golden-peak-live/1808661166?i=1808661940&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "6. divisjon",
       "band": "Søndre Nittedal Veterankorps",
       "result_piece": "Exultation",
       "recording_title": "Exultation - Live",
@@ -1031,6 +1241,16 @@
       "album": "Nm Janitsjar 2025 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/3ka66uHpJQSokg4QSmKCEM",
       "apple_music": "https://music.apple.com/us/album/christian-daae-p%C3%A5-maaenen-live/1808661166?i=1808661921&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "6. divisjon",
+      "band": "Tretten Musikkforening",
+      "result_piece": "Compostela",
+      "recording_title": "Compostella, The way of St James - Live",
+      "album": "Nm Janitsjar 2025 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/3baxtuMdLlqxFDxOpiwm0U",
+      "apple_music": "https://music.apple.com/us/album/compostella-the-way-of-st-james-live/1808661166?i=1808661416&uo=4"
     },
     {
       "year": 2025,
@@ -1071,6 +1291,16 @@
       "album": "Nm Janitsjar 2025 - 6. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/0B3QFSsavAAKaBf3Hqf8b1",
       "apple_music": "https://music.apple.com/us/album/eldorado-live/1808661166?i=1808662160&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "6. divisjon",
+      "band": "Åndalsnes Musikkforening",
+      "result_piece": "Ross Roy, Overture for Band",
+      "recording_title": "The Roy - Live",
+      "album": "Nm Janitsjar 2025 - 6. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5EMNSRa0oGJIGGVk0Wc3lf",
+      "apple_music": null
     },
     {
       "year": 2025,
@@ -1131,6 +1361,16 @@
       "album": "Nm Janitsjar 2025 - 7. divisjon (Live)",
       "spotify": "https://open.spotify.com/track/31eLk3hZgXzQEVTINUqEYK",
       "apple_music": "https://music.apple.com/us/album/rheinische-kirmest%C3%A4nze-live/1808647720?i=1808648140&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "7. divisjon",
+      "band": "Flisbyen Blåseensemble",
+      "result_piece": "Pilatus: Mountain of Dragons",
+      "recording_title": "Pilatus: Mountain of dragons - Live",
+      "album": "Nm Janitsjar 2025 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/6rCQlhku4LLzGE3qwEPx35",
+      "apple_music": "https://music.apple.com/us/album/pilatus-mountain-of-dragons-live/1808647720?i=1808647997&uo=4"
     },
     {
       "year": 2025,
@@ -1204,6 +1444,16 @@
     },
     {
       "year": 2025,
+      "division": "7. divisjon",
+      "band": "Øystese Musikklag",
+      "result_piece": "Concerto d’Amore",
+      "recording_title": "Concerto D´amore - Live",
+      "album": "Nm Janitsjar 2025 - 7. divisjon (Live)",
+      "spotify": "https://open.spotify.com/track/1jAZkrzKrA2506s0r979AH",
+      "apple_music": "https://music.apple.com/us/album/concerto-damore-live/1808647720?i=1808647972&uo=4"
+    },
+    {
+      "year": 2025,
       "division": "Elite",
       "band": "Alvøens Musikkforening",
       "result_piece": "El Jardin de Las Herspérides",
@@ -1211,6 +1461,16 @@
       "album": "Nm Janitsjar 2025 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/4wn8dQ9PbdUZeCPboEceYk",
       "apple_music": "https://music.apple.com/us/album/el-jardin-de-las-hesp%C3%A9rides-live/1808651022?i=1808651445&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "Elite",
+      "band": "Byneset Musikkorps",
+      "result_piece": "From Ancient Times",
+      "recording_title": "From Anciet Times - Live",
+      "album": "Nm Janitsjar 2025 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/5nfIGe1p0gbJEw7q89RIpO",
+      "apple_music": "https://music.apple.com/us/album/from-anciet-times-live/1808651022?i=1808651258&uo=4"
     },
     {
       "year": 2025,
@@ -1240,7 +1500,7 @@
       "recording_title": "Svit ur Bergakungen - Live",
       "album": "Nm Janitsjar 2025 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/2lnvhFpO0ItxeSMtAJzIP1",
-      "apple_music": null
+      "apple_music": "https://music.apple.com/us/album/svit-ur-bergakungen-live/1808651022?i=1808651786&uo=4"
     },
     {
       "year": 2025,
@@ -1281,6 +1541,16 @@
       "album": "Nm Janitsjar 2025 - Elitedivisjon (Live)",
       "spotify": "https://open.spotify.com/track/30C6rBhwy7acyeQbCLnzPc",
       "apple_music": "https://music.apple.com/us/album/the-merry-king-live/1808651022?i=1808651664&uo=4"
+    },
+    {
+      "year": 2025,
+      "division": "Elite",
+      "band": "Lørenskog Musikkorps",
+      "result_piece": "Symphony no. 1, ‘Gilgamesh’",
+      "recording_title": "Symphony No. 1: Gligamesh - Live",
+      "album": "Nm Janitsjar 2025 - Elitedivisjon (Live)",
+      "spotify": "https://open.spotify.com/track/0DiiSxEbs2GqsivWhfuM9D",
+      "apple_music": "https://music.apple.com/us/album/symphony-no-1-gligamesh-live/1808651022?i=1808651262&uo=4"
     },
     {
       "year": 2025,

--- a/config/streaming_cache.json.example
+++ b/config/streaming_cache.json.example
@@ -1,0 +1,9 @@
+{
+  "spotify": {
+    "album_tracks": {}
+  },
+  "apple": {
+    "album_tracks": {},
+    "album_searches": {}
+  }
+}

--- a/config/streaming_overrides.json
+++ b/config/streaming_overrides.json
@@ -77,6 +77,18 @@
       "spotify": "https://open.spotify.com/track/2bi2aO63xQmS475RjDl3Ba?si=5c4489ebaa1e4e7b",
       "allow_album_mismatch": true,
       "band_type": "brass"
+    },
+    {
+      "year": 2024,
+      "division": "Elite",
+      "band": "Christiania Blåseensemble",
+      "piece": "Vårofferet",
+      "album": "NM Janitsjar 2024 - Elitedivisjon (Live)",
+      "recording_title": "The Rite of Spring (Live)",
+      "spotify": "https://open.spotify.com/track/5BChs0DHLaQzUUsuzPKSWt?si=2577c646aaa54419",
+      "apple_music": "https://music.apple.com/no/album/the-rite-of-spring-live/1737790756?i=1737793781",
+      "notes": "Norwegian title 'Vårofferet' vs English album title 'The Rite of Spring'",
+      "band_type": "wind"
     }
   ]
 }


### PR DESCRIPTION
- Add --divisions CLI argument to filter processing to specific divisions (E, 1-7)
- Implement Apple Music album search result caching per year/division (for years >= 2012)
- Add DIVISION_CODE_MAP constant for division code to name mapping
- Add parse_divisions_argument() helper to validate division codes
- Extend StreamingCache with album_searches support and get/set methods
- Update _get_apple_tracks_for_division() to check cache before API calls
- Add division filtering in year_map construction
- Add logging for division filtering and cache hits/misses
- Move streaming_cache.json to .gitignore (machine-specific local file)
- Add streaming_cache.json.example as template

This reduces Apple Music API rate limiting by caching album searches
and allows targeted processing of specific divisions to avoid unnecessary API calls.